### PR TITLE
Add support for CSM Authorization sidecar via Helm

### DIFF
--- a/dell-csi-helm-installer/verify-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/verify-csi-vxflexos.sh
@@ -20,6 +20,7 @@ function verify-csi-vxflexos() {
   verify_alpha_snap_resources
   verify_snap_requirements
   verify_helm_3
+  verify_authorization_proxy_server
 }
 
 # Check if the SDC is installed and the kernel module loaded

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -449,6 +449,61 @@ function verify_helm_values_version() {
   check_error error
 }
 
+# verify that the authorization sidecar is configured correctly to be used with the authorization proxy server
+function verify_authorization_proxy_server() {
+  if [ ${NODE_VERIFY} -eq 0 ]; then
+    return
+  fi
+
+  log step "Verifying csm-authorization connectivity"
+
+  enabled=$(grep -v "#" $VALUES | grep -A1 "authorization:" | grep enabled | xargs | awk '{print $2}')
+  if [ "${enabled}" == "false"  ]; then
+    return
+  fi
+
+  proxyHost=$(grep -v "#" $VALUES | grep proxyHost | xargs | awk '{print $2}')
+  insecure=$(grep -v "#" $VALUES | grep -A10 "authorization:" | grep insecure | xargs | awk '{print $2}')
+  WGET=`which wget`
+  CURL=`which curl`
+
+  error=0
+  code=0
+  if [ ! -x "${WGET}" ]; then
+    if [ ! -x "${CURL}" ]; then
+    error=1
+    found_error "Unable to find wget or curl in the path. Install wget or curl to verify the csm-authorization proxy-server"
+    log step_failure
+    check_error error
+    return
+    fi
+
+    log info "Making HTTP request to https://"${proxyHost}"; expecting response code 502"
+    if [ "${insecure}" == "true" ]
+    then
+      code=$(curl -kIs https://"${proxyHost}" 2>&1 | grep "HTTP/1.1"| awk '{print $2}')
+    else
+      code=$(curl -Is https://"${proxyHost}" 2>&1 | grep "HTTP/1.1"| awk '{print $2}')
+    fi
+  fi
+
+  log info "Making HTTP request to https://"${proxyHost}"; expecting response code 502"
+  if [ "${insecure}" == "true" ]
+    then
+      code=$(wget --no-check-certificate --server-response --spider --quiet https://"${proxyHost}"  2>&1 | awk 'NR==1{print $2}')
+    else
+      code=$(wget --server-response --spider --quiet https:"${proxyHost}" 2>&1 | awk 'NR==1{print $2}')
+  fi
+
+  if [ "${code}" != "502" ]; then
+    error=1
+    found_error "did not get expected response code 502 from the the csm-authorization proxy-server, got "${code}""
+    log step_failure
+  fi
+
+   check_error error
+}
+
 #
 # main
 #

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -449,61 +449,6 @@ function verify_helm_values_version() {
   check_error error
 }
 
-# verify that the authorization sidecar is configured correctly to be used with the authorization proxy server
-function verify_authorization_proxy_server() {
-  if [ ${NODE_VERIFY} -eq 0 ]; then
-    return
-  fi
-
-  log step "Verifying csm-authorization connectivity"
-
-  enabled=$(grep -v "#" $VALUES | grep -A1 "authorization:" | grep enabled | xargs | awk '{print $2}')
-  if [ "${enabled}" == "false"  ]; then
-    return
-  fi
-
-  proxyHost=$(grep -v "#" $VALUES | grep proxyHost | xargs | awk '{print $2}')
-  insecure=$(grep -v "#" $VALUES | grep -A10 "authorization:" | grep insecure | xargs | awk '{print $2}')
-  WGET=`which wget`
-  CURL=`which curl`
-
-  error=0
-  code=0
-  if [ ! -x "${WGET}" ]; then
-    if [ ! -x "${CURL}" ]; then
-    error=1
-    found_error "Unable to find wget or curl in the path. Install wget or curl to verify the csm-authorization proxy-server"
-    log step_failure
-    check_error error
-    return
-    fi
-
-    log info "Making HTTP request to https://"${proxyHost}"; expecting response code 502"
-    if [ "${insecure}" == "true" ]
-    then
-      code=$(curl -kIs https://"${proxyHost}" 2>&1 | grep "HTTP/1.1"| awk '{print $2}')
-    else
-      code=$(curl -Is https://"${proxyHost}" 2>&1 | grep "HTTP/1.1"| awk '{print $2}')
-    fi
-  fi
-
-  log info "Making HTTP request to https://"${proxyHost}"; expecting response code 502"
-  if [ "${insecure}" == "true" ]
-    then
-      code=$(wget --no-check-certificate --server-response --spider --quiet https://"${proxyHost}"  2>&1 | awk 'NR==1{print $2}')
-    else
-      code=$(wget --server-response --spider --quiet https:"${proxyHost}" 2>&1 | awk 'NR==1{print $2}')
-  fi
-
-  if [ "${code}" != "502" ]; then
-    error=1
-    found_error "did not get expected response code 502 from the the csm-authorization proxy-server, got "${code}""
-    log step_failure
-  fi
-
-   check_error error
-}
-
 #
 # main
 #

--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -279,7 +279,7 @@ spec:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
             - name: INSECURE
-              value: "{{ .Values.authorization.insecure }}"
+              value: "{{ .Values.authorization.skipCertificateValidation }}"
             - name: PLUGIN_IDENTIFIER
               value: powerflex
             - name: ACCESS_TOKEN

--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -114,6 +114,12 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-controller
   namespace: {{ .Release.Namespace }}
+  {{- if hasKey .Values "authorization" }}
+  {{- if eq .Values.authorization.enabled true }}
+  annotations:
+      com.dell.karavi-authorization-proxy: "true"
+  {{ end }}
+  {{ end }}
 spec:
 {{- if gt (int .Values.controller.controllerCount) 1 }}
   strategy:
@@ -264,6 +270,37 @@ spec:
               mountPath: /var/run/csi
 {{- end }}
 {{- end }}
+{{- if hasKey .Values.controller "authorization" }}
+{{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-proxy
+          imagePullPolicy: Always
+          image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
+          env:
+            - name: PROXY_HOST
+              value: "{{ .Values.authorization.proxyHost }}"
+            - name: INSECURE
+              value: "{{ .Values.authorization.insecure }}"
+            - name: PLUGIN_IDENTIFIER
+              value: powerflex
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: access
+            - name: REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: refresh
+          volumeMounts:
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            - name: proxy-server-root-certificate
+              mountPath: /etc/karavi-authorization/root-certificates
+            - name: vxflexos-config-params
+              mountPath: /etc/karavi-authorization
+{{- end }}
+{{- end }}
         - name: driver
           image: "{{ required "Must provide the driver image repository." .Values.images.driverRepository }}/{{ .Chart.Name }}:v{{ .Values.version }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -304,6 +341,16 @@ spec:
         - name: vxflexos-config-params
           configMap:
             name: {{ .Release.Name }}-config-params
+        {{- if hasKey .Values "authorization" }}
+        {{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        - name: proxy-server-root-certificate
+          secret:
+            secretName: proxy-server-root-certificate
+        {{ end }}
+        {{ end }}
 {{- if ge (int .Values.certSecretCount) 1 }}
         - name: certs
           projected:

--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -270,7 +270,7 @@ spec:
               mountPath: /var/run/csi
 {{- end }}
 {{- end }}
-{{- if hasKey .Values.controller "authorization" }}
+{{- if hasKey .Values "authorization" }}
 {{- if eq .Values.authorization.enabled true }}
         - name: karavi-authorization-proxy
           imagePullPolicy: Always

--- a/helm/csi-vxflexos/templates/node.yaml
+++ b/helm/csi-vxflexos/templates/node.yaml
@@ -63,6 +63,12 @@ apiVersion: apps/v1
 metadata:
   name: {{ .Release.Name }}-node
   namespace: {{ .Release.Namespace }}
+  {{- if hasKey .Values "authorization" }}
+  {{- if eq .Values.authorization.enabled true }}
+  annotations:
+    com.dell.karavi-authorization-proxy: "true"
+  {{ end }}
+  {{ end }}
 spec:
   selector:
     matchLabels:
@@ -136,6 +142,37 @@ spec:
               mountPath: /vxflexos-config-params
 {{- end }}
 {{- end }}
+{{- if hasKey .Values "authorization" }}
+{{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-proxy
+          imagePullPolicy: Always
+          image: {{ required "Must provide the authorization sidecar container image." .Values.authorization.sidecarProxyImage }}
+          env:
+            - name: PROXY_HOST
+              value: "{{ .Values.authorization.proxyHost }}"
+            - name: INSECURE
+              value: "{{ .Values.authorization.insecure }}"
+            - name: PLUGIN_IDENTIFIER
+              value: powerflex
+            - name: ACCESS_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: access
+            - name: REFRESH_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-authz-tokens
+                  key: refresh
+          volumeMounts:
+            - name: karavi-authorization-config
+              mountPath: /etc/karavi-authorization/config
+            - name: proxy-server-root-certificate
+              mountPath: /etc/karavi-authorization/root-certificates
+            - name: vxflexos-config-params
+              mountPath: /etc/karavi-authorization
+{{ end }}
+{{ end }}
         - name: driver
           securityContext:
             privileged: true
@@ -321,6 +358,16 @@ spec:
                       path: cert-{{ $e }}
 {{- end }}
 {{- end }}
+{{- if hasKey .Values "authorization" }}
+{{- if eq .Values.authorization.enabled true }}
+        - name: karavi-authorization-config
+          secret:
+            secretName: karavi-authorization-config
+        - name: proxy-server-root-certificate
+          secret:
+            secretName: proxy-server-root-certificate
+{{ end }}
+{{ end }}
 {{- if hasKey .Values "podmon" }}
 {{- if eq .Values.podmon.enabled true }}
         - name: usr-bin

--- a/helm/csi-vxflexos/templates/node.yaml
+++ b/helm/csi-vxflexos/templates/node.yaml
@@ -151,7 +151,7 @@ spec:
             - name: PROXY_HOST
               value: "{{ .Values.authorization.proxyHost }}"
             - name: INSECURE
-              value: "{{ .Values.authorization.insecure }}"
+              value: "{{ .Values.authorization.skipCertificateValidation }}"
             - name: PLUGIN_IDENTIFIER
               value: powerflex
             - name: ACCESS_TOKEN

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -180,3 +180,16 @@ podmon:
   #    - "--leaderelection=false"
   #    - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
 
+# Authorization: enable csm-authorization for RBAC
+authorization:
+  # enable: Enable/Disable csm-authorization
+  enabled: false
+
+  # sidecarProxyImage: the container images used for the csm-authorization-sidecar.
+  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
+
+  # proxyHost: hostname of the csm-authorization server
+  proxyHost:
+
+  # insecure: Enable/Disable certificate validation of the csm-authorization server
+  insecure: true

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -180,16 +180,28 @@ podmon:
   #    - "--leaderelection=false"
   #    - "--driver-config-params=/vxflexos-config-params/driver-config-params.yaml"
 
-# Authorization: enable csm-authorization for RBAC
+# CSM module attributes
+# authorization: enable csm-authorization for RBAC
+# Deploy and configure authorization before installing driver
+# Allowed values:
+#   "true" - authorization is enabled
+#   "false" - authorization is disabled
+# Default value: "false"
 authorization:
-  # enable: Enable/Disable csm-authorization
   enabled: false
 
-  # sidecarProxyImage: the container images used for the csm-authorization-sidecar.
+  # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
+  # Default value: dellemc/csm-authorization-sidecar:v1.0.0
+  # Example: 0.0.0.1:5000/csm-authorization-sidecar:v1.0.0
   sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
 
   # proxyHost: hostname of the csm-authorization server
+  # Default value: None
   proxyHost:
 
-  # insecure: Enable/Disable certificate validation of the csm-authorization server
-  insecure: true
+  # skipCertificateValidation: certificate validation of the csm-authorization server
+  # Allowed Values:
+  #   "true" - TLS certificate verification will be skipped
+  #   "false" - TLS certificate will be verified 
+  # Default value: "true" 
+  skipCertificateValidation: true

--- a/samples/config.yaml
+++ b/samples/config.yaml
@@ -1,12 +1,16 @@
-  # Username for accessing PowerFlex system.	
+  # Username for accessing PowerFlex system.
+  # If authorization is enabled, username will be ignored.
 - username: "admin"
-  # Password for accessing PowerFlex system.	
+  # Password for accessing PowerFlex system.
+  # If authorization is enabled, password will be ignored.
   password: "password"
   # System name/ID of PowerFlex system.	
   systemID: "ID1"
   # Previous names used in secret of PowerFlex system.
   allSystemNames: "pflex-1,pflex-2"
   # REST API gateway HTTPS endpoint for PowerFlex system.
+  # If authorization is enabled, endpoint should be the HTTPS localhost endpoint that 
+  # the authorization sidecar will listen on
   endpoint: "https://127.0.0.1"
   # Determines if the driver is going to validate certs while connecting to PowerFlex REST API interface.
   # Allowed values: true or false

--- a/samples/secret/karavi-authorization-config.json
+++ b/samples/secret/karavi-authorization-config.json
@@ -1,0 +1,1 @@
+[{"username":"","password":"","intendedEndpoint":"","endpoint":"https://localhost:9400","systemID":"","insecure":true,"isDefault":true}]


### PR DESCRIPTION
# Description
This PR implements install support for CSM Authorization sidecar in the helm chart

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|dell/csm#78 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- The PowerFlex driver is deployed via Helm with Authorization disabled. Ensured the Authorization sidecar does not get deployed.
- The PowerFlex driver is deployed via Helm with Authorization enabled. Ensure the Authorization sidecar is deployed and works correctly.
- There is an existing cluster with the PowerFlex driver deployed and the previous version of the Authorization sidecar deployed. The Authorization sidecar is upgraded via the driver's helm chart.
