### PR TITLE
removing example for authorization image

### DIFF
--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -214,7 +214,6 @@ authorization:
 
   # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
   # Default value: dellemc/csm-authorization-sidecar:v1.0.0
-  # Example: 0.0.0.1:5000/csm-authorization-sidecar:v1.0.0
   sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
 
   # proxyHost: hostname of the csm-authorization server


### PR DESCRIPTION
Removing example section for csm-authorization image .

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|     #[109 ](https://github.com/dell/csm/issues/109) |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
