### PR TITLE
Prep work for 2.1.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ LABEL vendor="Dell Inc." \
     name="csi-powerflex" \
     summary="CSI Driver for Dell EMC PowerFlex" \
     description="CSI Driver for provisioning persistent storage from Dell EMC PowerFlex" \
-    version="2.0.0" \
+    version="2.1.0" \
     license="Apache-2.0"
 COPY ./licenses /licenses
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## Description
 CSI Driver for PowerFlex is part of the [CSM (Container Storage Modules)](https://github.com/dell/csm) open-source suite of Kubernetes storage enablers for Dell EMC products. CSI Driver for PowerFlex is a Container Storage Interface (CSI) driver that provides support for provisioning persistent storage using Dell EMC PowerFlex storage array. 
 
-It supports CSI specification version 1.3.
+It supports CSI specification version 1.5.
 
 This project may be compiled as a stand-alone binary using Golang that, when run, provides a valid CSI endpoint. It also can be used as a precompiled container image.
 

--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -15,7 +15,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="2.0.0"
+DEFAULT_DRIVER_VERSION="2.1.0"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it

--- a/go.mod
+++ b/go.mod
@@ -20,9 +20,9 @@ require (
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/podmon v1.0.0
-	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v0.0.0-20211104171507-7c7d0b6e3d35
+	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.0.0
 	github.com/dell/gocsi v1.5.0
-	github.com/dell/gofsutil v1.6.0
+	github.com/dell/gofsutil v1.7.0
 	github.com/dell/goscaleio v1.6.0
 	github.com/fsnotify/fsnotify v1.4.9
 	github.com/golang/protobuf v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -174,12 +174,12 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dell/dell-csi-extensions/podmon v1.0.0 h1:QoxioaFfjIP6cJ4s166A1JhgxIXWe/H0A60edO6nf4E=
 github.com/dell/dell-csi-extensions/podmon v1.0.0/go.mod h1:Jjt+zHbLIZ3qJMug17WBYdz7wu90+hd65kgJwv8ZOec=
-github.com/dell/dell-csi-extensions/volumeGroupSnapshot v0.0.0-20211104171507-7c7d0b6e3d35 h1:8NsQgwbRJRKFprWdWCv4LDYmZaoaafWH7dIGHCcGsmI=
-github.com/dell/dell-csi-extensions/volumeGroupSnapshot v0.0.0-20211104171507-7c7d0b6e3d35/go.mod h1:5yDbA4Whm93zqgYSEdf2dgntm0JZLW60Eu7ABeZEhE4=
+github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.0.0 h1:a/feoPax/F05B991FIQXhFBWPi6YIK3U2dxKotJo3DY=
+github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.0.0/go.mod h1:5yDbA4Whm93zqgYSEdf2dgntm0JZLW60Eu7ABeZEhE4=
 github.com/dell/gocsi v1.5.0 h1:qi2T6H6JHDo9sJEw24jo6Z88fJszBXfQc3lxOBaUijo=
 github.com/dell/gocsi v1.5.0/go.mod h1:nIsIXXB5JpAvOQ0//gtPGULC2+NUddpi5qwpBeMhiLs=
-github.com/dell/gofsutil v1.6.0 h1:u5PiMJIyecAWpSlPloov1/3LF5OWrcjJwoFF8dWkjcA=
-github.com/dell/gofsutil v1.6.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5ghHlvhg=
+github.com/dell/gofsutil v1.7.0 h1:1yKLb4EofnLKIe4+Vs58/q9A18y7fPZJwfgwi2DqNlw=
+github.com/dell/gofsutil v1.7.0/go.mod h1:98Wpcg7emz4iGgY16fd4MKpnal2SX2hBiwP5ghHlvhg=
 github.com/dell/goscaleio v1.6.0 h1:lbPf22YPwUTfrZCBF/E+uDawm2IFlBWTRqCy6PskeMg=
 github.com/dell/goscaleio v1.6.0/go.mod h1:4Yc8lP8ZeVyo+fUKuarhcyAu45saoYwRVnab/FoK1tg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/helm/csi-vxflexos/Chart.yaml
+++ b/helm/csi-vxflexos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.0.0"
+appVersion: "2.1.0"
 kubeVersion: ">= 1.20.0 < 1.23.0"
 description: |
   VxFlex OS CSI (Container Storage Interface) driver Kubernetes
@@ -13,4 +13,4 @@ maintainers:
 name: csi-vxflexos
 sources:
 - https://github.com/dell/csi-vxflexos
-version: "2.0.0"
+version: "2.1.0"

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -3,7 +3,7 @@
 
 # "version" is used to verify the values file matches driver version
 # Not recommend to change
-version: 2.0.0
+version: 2.1.0
 
 images:
   # "driver" defines the container image, used for the driver container.


### PR DESCRIPTION
# Description
This PR updates go.mod and increases version from 2.0.0 -> 2.1.0

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Built image, deployed image, and ran provisioning test on it 
- [x] Ran unit tests  
