### PR TITLE
Revert gosec exclude args

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -50,7 +50,6 @@ jobs:
       - name: Run Go Security
         uses: securego/gosec@master
         with:
-          # added additional exclude arguments after gosec v2.9.4 came out
           args: -exclude=G304 ./...
   malware_security_scan:
     name: Malware Scanner

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G108,G304 ./...
+          args: -exclude=G304 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G108,G304,G402 ./...
+          args: -exclude=G108,G304 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,9 +1,9 @@
 name: Workflow
 on:
   push:
-    branches: [ revert-gosec-exclude-args ]
+    branches: [ main ]
   pull_request:
-    branches: [ revert-gosec-exclude-args ]
+    branches: [ main ]
 jobs:
   code-check:
     name: Check Go formatting, linting, vetting
@@ -51,7 +51,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: ./...
+          args: -exclude=G304 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G304 ./...
+          args: ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest

--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -1,9 +1,9 @@
 name: Workflow
 on:
   push:
-    branches: [ main ]
+    branches: [ revert-gosec-exclude-args ]
   pull_request:
-    branches: [ main ]
+    branches: [ revert-gosec-exclude-args ]
 jobs:
   code-check:
     name: Check Go formatting, linting, vetting
@@ -51,7 +51,7 @@ jobs:
         uses: securego/gosec@master
         with:
           # added additional exclude arguments after gosec v2.9.4 came out
-          args: -exclude=G108,G301,G302,G304,G307,G402 ./...
+          args: -exclude=G108,G304,G402 ./...
   malware_security_scan:
     name: Malware Scanner
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Description
In version 2.9.4 of gosec, there was a bug required us to add a bunch of extra exclude flags to gosec. This bug has now been fully fixed in 2.9.6, so we can get rid of those flags.

# GitHub Issues
None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Ran actions successfully
