### PR TITLE
Race fix

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,7 +32,7 @@ jobs:
           repository: 'dell/gofsutil'
           path: 'gofsutil'
       - name: Run unit tests and check package coverage
-        uses: dell/common-github-actions/go-code-tester@pflex-unit-test-no-race
+        uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
           test-folder: "./service"

--- a/service/service.go
+++ b/service/service.go
@@ -157,6 +157,7 @@ func (s *service) ProcessMapSecretChange() error {
 	}
 	vc.WatchConfig()
 	vc.OnConfigChange(func(e fsnotify.Event) {
+		// Putting in mutex to allow tests to pass with race flag
 		mx.Lock()
 		defer mx.Unlock()
 		Log.WithField("file", DriverConfigParamsFile).Info("log configuration file changed")
@@ -173,6 +174,7 @@ func (s *service) ProcessMapSecretChange() error {
 	va.WatchConfig()
 
 	va.OnConfigChange(func(e fsnotify.Event) {
+		// Putting in mutex to allow tests to pass with race flag
 		mx.Lock()
 		defer mx.Unlock()
 		Log.WithField("file", ArrayConfigFile).Info("array configuration file changed")
@@ -398,7 +400,8 @@ func (s *service) BeforeServe(
 
 // Probe all systems managed by driver
 func (s *service) doProbe(ctx context.Context) error {
-
+	
+	// Putting in mutex to allow tests to pass with race flag
 	px.Lock()
 	defer px.Unlock()
 

--- a/service/service.go
+++ b/service/service.go
@@ -156,6 +156,9 @@ func (s *service) ProcessMapSecretChange() error {
 	}
 	vc.WatchConfig()
 	vc.OnConfigChange(func(e fsnotify.Event) {
+		mx.Lock()
+		defer mx.Unlock()
+		Log.WithField("file", DriverConfigParamsFile).Info("log configuration file changed")
 		if err := s.updateDriverConfigParams(Log, vc); err != nil {
 			Log.Warn(err)
 		}
@@ -257,9 +260,6 @@ func New() Service {
 }
 
 func (s *service) updateDriverConfigParams(logger *logrus.Logger, v *viper.Viper) error {
-
-	mx.Lock()
-	defer mx.Unlock()
 
 	logFormat := v.GetString("CSI_LOG_FORMAT")
 	logFormat = strings.ToLower(logFormat)

--- a/service/service.go
+++ b/service/service.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
@@ -170,6 +171,7 @@ func (s *service) ProcessMapSecretChange() error {
 	va.OnConfigChange(func(e fsnotify.Event) {
 		mx.Lock()
 		defer mx.Unlock()
+
 		Log.WithField("file", ArrayConfigFile).Info("array configuration file changed")
 		var err error
 		s.opts.arrays, err = getArrayConfig(context.Background())
@@ -578,7 +580,7 @@ func getArrayConfig(ctx context.Context) (map[string]*ArrayConnectionData, error
 		return nil, fmt.Errorf(fmt.Sprintf("File %s does not exist", ArrayConfigFile))
 	}
 
-	config, err := ioutil.ReadFile(ArrayConfigFile)
+	config, err := ioutil.ReadFile(filepath.Clean(ArrayConfigFile))
 	if err != nil {
 		return nil, fmt.Errorf(fmt.Sprintf("File %s errors: %v", ArrayConfigFile, err))
 	}

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -257,8 +257,12 @@ func (f *feature) getService() *service {
 	svc.volumePrefixToSystems = map[string][]string{}
 	svc.connectedSystemNameToID = map[string]string{}
 	svc.privDir = "./features"
-	ArrayConfigFile = "./features/array-config/config"
-	DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
+        if ArrayConfigFile == "" {
+                ArrayConfigFile = "./features/array-config/config"
+        }
+        if DriverConfigParamsFile == "" {
+                DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
+        }
 
 	if f.service != nil {
 		return f.service


### PR DESCRIPTION
# Description
Allow tests to pass with the race flag by not creating logfiles over and over in tests and by adding a couple of mutexes into logging and probing code. Also, change the actions to pull from the main branch, which includes the race flag in the tests.

# GitHub Issues
List the GitHub issues impacted by this PR:
None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Tests run overnight by @nb950 to make sure that the race condition alerts were really gone.