### PR TITLE
Comment out mkfs format option

### DIFF
--- a/samples/storageclass/storageclass-xfs.yaml
+++ b/samples/storageclass/storageclass-xfs.yaml
@@ -28,8 +28,8 @@ parameters:
   # format options to pass to mkfs
   # Allowed values: A string dictating the fs options you want passed
   # Optional: true
-  # Delete the line below if you do not plan on using mkfsFormatOption
-  mkfsFormatOption: "<mkfs_format_option>" # Insert file system format option
+  # Uncomment the line below if you want to use mkfsFormatOption
+  # mkfsFormatOption: "<mkfs_format_option>" # Insert file system format option
   # Filesytem type for volumes created by storageclass
   # Allowed values: "ext4" or "xfs"
   # Optional: true

--- a/samples/storageclass/storageclass.yaml
+++ b/samples/storageclass/storageclass.yaml
@@ -31,8 +31,8 @@ parameters:
   # format options to pass to mkfs
   # Allowed values: A string dictating the fs options you want passed
   # Optional: true
-  # Delete the line below if you do not plan on using mkfsFormatOption
-  mkfsFormatOption: "<mkfs_format_option>" # Insert file system format option
+  # Uncomment the line below if you want to use mkfsFormatOption
+  # mkfsFormatOption: "<mkfs_format_option>" # Insert file system format option
 # volumeBindingMode determines how volume binding and dynamic provisioning should occur
 # Allowed values: 
 #  Immediate: volume binding and dynamic provisioning occurs once PVC is created


### PR DESCRIPTION
# Description
Unlike other optional parameters in the storageclass yaml files, the `mkfsFormatOption` parameter was not commented out -- so if it wasn't deleted by a user not interested in it, it would break as soon as you tried mounting volumes. 

# GitHub Issues
None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Installed the driver with this commented out and it works just fine.
