### PR TITLE
Race fix

### DIFF
--- a/.github/workflows/actions.yaml
+++ b/.github/workflows/actions.yaml
@@ -32,7 +32,7 @@ jobs:
           repository: 'dell/gofsutil'
           path: 'gofsutil'
       - name: Run unit tests and check package coverage
-        uses: dell/common-github-actions/go-code-tester@pflex-unit-test-no-race
+        uses: dell/common-github-actions/go-code-tester@main
         with:
           threshold: 90
           test-folder: "./service"

--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ push: docker
 
 # Windows or Linux; requires no hardware
 unit-test:
-	( cd service; go clean -cache; CGO_ENABLED=0 GO111MODULE=on go test -v -coverprofile=c.out ./... )
+	( cd service; go clean -cache; CGO_ENABLED=1 GO111MODULE=on go test -v -race -coverprofile=c.out ./... )
 
 # Linux only; populate env.sh with the hardware parameters
 integration-test:

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -852,6 +852,19 @@ Feature: VxFlex OS CSI interface
     # Get different error message on Windows vs. Linux
     Then the error contains "unable to login to VxFlexOS Gateway"
 
+  Scenario: Call ControllerGetVolume good scenario
+    Given a VxFlexOS service
+    And I call Probe
+    When I call ControllerGetVolume
+    Then a valid ControllerGetVolumeResponse is returned
+  
+  Scenario: Call ControllerGetVolume bad scenario
+    Given a VxFlexOS service
+    And I call Probe
+    And I induce error "NoVolumeIDError"
+    When I call ControllerGetVolume
+    Then the error contains "volume ID is required"
+
   Scenario: Test getArrayConfig with invalid config file
     Given an invalid config <configPath>
     When I call getArrayConfig
@@ -868,16 +881,3 @@ Feature: VxFlex OS CSI interface
       | "features/array-config/invalid_endpoint"    | "invalid value for Endpoint"                                          |
       | "features/array-config/two_default_array"   | "'isDefault' parameter presents more than once in storage array list" |
       | "features/array-config/empty"               | "arrays details are not provided in vxflexos-creds secret"            |
-
-  Scenario: Call ControllerGetVolume good scenario
-    Given a VxFlexOS service
-    And I call Probe
-    When I call ControllerGetVolume
-    Then a valid ControllerGetVolumeResponse is returned
-  
-  Scenario: Call ControllerGetVolume bad scenario
-    Given a VxFlexOS service
-    And I call Probe
-    And I induce error "NoVolumeIDError"
-    When I call ControllerGetVolume
-    Then the error contains "volume ID is required"

--- a/service/service.go
+++ b/service/service.go
@@ -400,7 +400,7 @@ func (s *service) BeforeServe(
 
 // Probe all systems managed by driver
 func (s *service) doProbe(ctx context.Context) error {
-	
+
 	// Putting in mutex to allow tests to pass with race flag
 	px.Lock()
 	defer px.Unlock()

--- a/service/service.go
+++ b/service/service.go
@@ -57,6 +57,7 @@ const (
 )
 
 var mx = sync.Mutex{}
+var px = sync.Mutex{}
 
 // ArrayConfigFile is file name with array connection data
 var ArrayConfigFile string
@@ -156,6 +157,9 @@ func (s *service) ProcessMapSecretChange() error {
 	}
 	vc.WatchConfig()
 	vc.OnConfigChange(func(e fsnotify.Event) {
+		// Putting in mutex to allow tests to pass with race flag
+		mx.Lock()
+		defer mx.Unlock()
 		Log.WithField("file", DriverConfigParamsFile).Info("log configuration file changed")
 		if err := s.updateDriverConfigParams(Log, vc); err != nil {
 			Log.Warn(err)
@@ -164,22 +168,21 @@ func (s *service) ProcessMapSecretChange() error {
 
 	// dynamic array secret change
 	va := viper.New()
-	// /vxflexos-config/config
 	va.SetConfigFile(ArrayConfigFile)
-	va.SetConfigType("ini")
 	Log.WithField("file", ArrayConfigFile).Info("array configuration file")
 
 	va.WatchConfig()
 
 	va.OnConfigChange(func(e fsnotify.Event) {
+		// Putting in mutex to allow tests to pass with race flag
+		mx.Lock()
+		defer mx.Unlock()
 		Log.WithField("file", ArrayConfigFile).Info("array configuration file changed")
 		var err error
 		s.opts.arrays, err = getArrayConfig(context.Background())
 		if err != nil {
 			Log.WithError(err).Error("unable to reload multi array config file")
 		}
-		mx.Lock()
-		defer mx.Unlock()
 		err = s.doProbe(context.Background())
 		if err != nil {
 			Log.WithError(err).Error("unable to probe array in multi array config")
@@ -204,7 +207,6 @@ func (s *service) logCsiNodeTopologyKeys() error {
 
 	csiNodes, err := K8sClientset.StorageV1().CSINodes().List(context.TODO(), metav1.ListOptions{})
 	node, err := s.NodeGetInfo(context.Background(), nil)
-	fmt.Printf("debug get csinode info")
 	if node != nil {
 		Log.WithField("node info", node.NodeId).Info("NodeInfo ID")
 		segMap := node.AccessibleTopology.Segments
@@ -391,8 +393,6 @@ func (s *service) BeforeServe(
 	s.systems = make(map[string]*sio.System)
 
 	if _, ok := csictx.LookupEnv(ctx, "X_CSI_VXFLEXOS_NO_PROBE_ON_START"); !ok {
-		mx.Lock()
-		defer mx.Unlock()
 		return s.doProbe(ctx)
 	}
 	return nil
@@ -400,6 +400,10 @@ func (s *service) BeforeServe(
 
 // Probe all systems managed by driver
 func (s *service) doProbe(ctx context.Context) error {
+	
+	// Putting in mutex to allow tests to pass with race flag
+	px.Lock()
+	defer px.Unlock()
 
 	if !strings.EqualFold(s.mode, "node") {
 		if err := s.systemProbeAll(ctx); err != nil {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -257,8 +257,12 @@ func (f *feature) getService() *service {
 	svc.volumePrefixToSystems = map[string][]string{}
 	svc.connectedSystemNameToID = map[string]string{}
 	svc.privDir = "./features"
-	ArrayConfigFile = "./features/array-config/config"
-	DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
+        if ArrayConfigFile == "" {
+                ArrayConfigFile = "./features/array-config/config"
+        }
+        if DriverConfigParamsFile == "" {
+                DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
+        }
 
 	if f.service != nil {
 		return f.service

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -257,12 +257,12 @@ func (f *feature) getService() *service {
 	svc.volumePrefixToSystems = map[string][]string{}
 	svc.connectedSystemNameToID = map[string]string{}
 	svc.privDir = "./features"
-        if ArrayConfigFile == "" {
-                ArrayConfigFile = "./features/array-config/config"
-        }
-        if DriverConfigParamsFile == "" {
-                DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
-        }
+	if ArrayConfigFile == "" {
+		ArrayConfigFile = "./features/array-config/config"
+	}
+	if DriverConfigParamsFile == "" {
+		DriverConfigParamsFile = "./features/driver-config/logConfig.yaml"
+	}
 
 	if f.service != nil {
 		return f.service


### PR DESCRIPTION
# Description
Allow tests to pass with the race flag by not creating logfiles over and over in tests and by adding a couple of mutexes into logging and probing code. Also, change the actions to pull from the main branch, which includes the race flag in the tests.

EDIT: Also changed the Makefile to include the `-race` flag. To do this I had to set `CGO_ENABLED-1`. If anyone has any input on this, I would appreciate it.

# GitHub Issues
List the GitHub issues impacted by this PR:
None

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Tests run overnight by @nb950 to make sure that the race condition alerts were really gone.