### PR TITLE
Add CSM PodMon & VGsnapshotter images

### DIFF
--- a/helm/csi-vxflexos/templates/driver-config-params.yaml
+++ b/helm/csi-vxflexos/templates/driver-config-params.yaml
@@ -8,8 +8,8 @@ data:
     CSI_LOG_LEVEL: "{{ .Values.logLevel }}"
     CSI_LOG_FORMAT: "{{ .Values.logFormat }}"
     {{ if .Values.podmon.enabled }}
-    PODMON_CONTROLLER_LOG_LEVEL: "debug"
-    PODMON_CONTROLLER_LOG_FORMAT: "TEXT"
-    PODMON_NODE_LOG_LEVEL: "debug"
-    PODMON_NODE_LOG_FORMAT: "TEXT"
+    PODMON_CONTROLLER_LOG_LEVEL: "{{ .Values.logLevel }}"
+    PODMON_CONTROLLER_LOG_FORMAT: "{{ .Values.logFormat }}"
+    PODMON_NODE_LOG_LEVEL: "{{ .Values.logLevel }}"
+    PODMON_NODE_LOG_FORMAT: "{{ .Values.logFormat }}"
     {{ end }}

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -181,13 +181,13 @@ monitor:
 # These options control the running of the vgsnapshotter container
 vgsnapshotter:
   enabled: false
-  image:
+  image: dellemc/csi-volumegroup-snapshotter:v1.0.0
 
 # Podmon is an optional feature under development and tech preview.
 # Enable this feature only after contact support for additional information
 podmon:
   enabled: false
-  image: 
+  image: dellemc/podmon:v1.0.1
   #controller:
   #  args:
   #    - "--csisock=unix:/var/run/csi/csi.sock"


### PR DESCRIPTION
Apply same log level as the driver for PodMon

# Description
The default images for CSM module were missing and difficult to find out if you don't know where to look for.

Moreover, the log level for PodMon was hard-coded to `debug`. This is using the same level as set for the driver ; i.e. `info` by default.

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
This was functionally tested on CSC lab during a customer PoC.