### PR TITLE
update default sidecar image version

### DIFF
--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -187,7 +187,7 @@ vgsnapshotter:
 # Enable this feature only after contact support for additional information
 podmon:
   enabled: false
-  image: dellemc/podmon:v1.0.1
+  image: dellemc/podmon:v1.1.0
   #controller:
   #  args:
   #    - "--csisock=unix:/var/run/csi/csi.sock"
@@ -214,8 +214,8 @@ authorization:
   enabled: false
 
   # sidecarProxyImage: the container image used for the csm-authorization-sidecar.
-  # Default value: dellemc/csm-authorization-sidecar:v1.0.0
-  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.0.0
+  # Default value: dellemc/csm-authorization-sidecar:v1.2.0
+  sidecarProxyImage: dellemc/csm-authorization-sidecar:v1.2.0
 
   # proxyHost: hostname of the csm-authorization server
   # Default value: None


### PR DESCRIPTION
# Description
Updating the default value of the podmon and auth sidecar to CSM 1.2 version 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/128|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

