### PR TITLE
fix e2e test bug

### DIFF
--- a/test/e2e-fsgroup/fs.go
+++ b/test/e2e-fsgroup/fs.go
@@ -145,6 +145,7 @@ func doOneCyclePVCTest(ctx context.Context, policy string, accessMode v1.Persist
 
 	testParameters[testParameters["scParamStoragePoolKey"]] = testParameters["scParamStoragePoolValue"]
 	testParameters[testParameters["scParamStorageSystemKey"]] = testParameters["scParamStorageSystemValue"]
+	testParameters[testParameters["scParamFsTypeKey"]] = testParameters["scParamFsTypeValue"]
 
 	storageclasspvc, pvclaim, err := createPVCAndStorageClass(client,
 		namespace, nil, testParameters, testParameters["diskSize"], nil, "", false, "")


### PR DESCRIPTION
# Description
There was a bug in fsGroup e2e testing that would cause ReadWriteOnceWithFsType to fail 
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Ran tests on OS with changes

