### PR TITLE
Fixing offline bundle creator driver image tag

### DIFF
--- a/dell-csi-helm-installer/csi-offline-bundle.sh
+++ b/dell-csi-helm-installer/csi-offline-bundle.sh
@@ -87,8 +87,8 @@ build_image_manifest() {
 
   # Forming this only for drivers supporting standalone helm charts
   if [ ! -z ${DRIVERREPO} ]; then 
-   echo "${DRIVERREPO}/${DRIVERNAME}\:${DRIVERVERSIONVALUESYAML}"
-   echo "${DRIVERREPO}/${DRIVERNAME}:${DRIVERVERSIONVALUESYAML}" >> "${IMAGEMANIFEST}.tmp"
+   echo "${DRIVERREPO}/${DRIVERNAME}\:v${DRIVERVERSIONVALUESYAML}"
+   echo "${DRIVERREPO}/${DRIVERNAME}:v${DRIVERVERSIONVALUESYAML}" >> "${IMAGEMANIFEST}.tmp"
   fi
   # sort and uniqify the list
   cat "${IMAGEMANIFEST}.tmp" | sort | uniq > "${IMAGEMANIFEST}"


### PR DESCRIPTION
# Description
The offline installer didn't pull the driver image due to incorrect tag (2.3.0 <> v2.3.0).
This PR resolves this in the dell-csi-helm-installer/csi-offline-bundle.sh file.


# GitHub Issues : https://github.com/dell/csm/issues/435
-

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- The updated script is tested with offline installation and works fine.
