### PR TITLE
Truncate snapshot name to max characters length

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -3,6 +3,7 @@ package service
 import (
 	"errors"
 	"fmt"
+	"math"
 	"net/http"
 	"strconv"
 	"strings"
@@ -1704,7 +1705,8 @@ func (s *service) CreateSnapshot(
 	if req.Name != "" && len(req.Name) > 31 {
 		name := req.Name
 		name = strings.Replace(name, "snapshot-", "sn-", 1)
-		name = name[0:31]
+		length := int(math.Min(float64(len(name)), 31))
+		name = name[0:length]
 		Log.Printf("Requested name %s longer than 31 character max, truncated to %s\n", req.Name, name)
 		req.Name = name
 	}


### PR DESCRIPTION
# Description
During `csi-sanity testing`, there was no verification that the adjusted name of the snapshot name would be 31 characters or greater. This caused a truncated name of less than 31 characters to cause an `out-of-bound` exception during testing.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
https://github.com/dell/csm/issues/350

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Tested locally with the `csi-sanity` tests. No crashing of snapshot name creations occurred.
