### PR TITLE
Comment out protection domain field in storageclass yamls

### DIFF
--- a/samples/storageclass/storageclass-xfs.yaml
+++ b/samples/storageclass/storageclass-xfs.yaml
@@ -24,7 +24,8 @@ parameters:
   # Protection domain that storage pool above belongs to
   # Needed if array has two storagepools that share the same name, but belong to different protection domains
   # Optional: true
-  protectiondomain: # Insert Protection domain name
+  # Uncomment the line below if you want to use protectiondomain
+  # protectiondomain: # Insert Protection domain name
   # System you would like this storage class to use
   # Allowed values: one string for system ID
   # Optional: false

--- a/samples/storageclass/storageclass.yaml
+++ b/samples/storageclass/storageclass.yaml
@@ -27,7 +27,8 @@ parameters:
   # Protection domain that storage pool above belongs to
   # Needed if array has two storagepools that share the same name, but belong to different protection domains
   # Optional: true
-  protectiondomain: # Insert Protection domain name
+  # Uncomment the line below if you want to use protectiondomain
+  # protectiondomain: # Insert Protection domain name
   # System you would like this storage class to use
   # Allowed values: one string for system ID
   # Optional: false


### PR DESCRIPTION
# Description
Comment out the `protectiondomain` field in the storageclass yamls since it is optional. This follows the convention we set by commenting out `mkfsFormatOption` in the same yamls.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/350 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Applied storageclasses with this field commented out and successfully ran cert-csi against the setup.
