### PR TITLE
update ubi image to 8.6-902.1661794353 and fsutil to current

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,10 +9,11 @@ require (
 	github.com/akutz/memconn v0.1.0
 	github.com/container-storage-interface/spec v1.5.0
 	github.com/cucumber/godog v0.12.1
+	github.com/dell/dell-csi-extensions/common v1.0.1-0.20220526070836-43b4ac597bf3
 	github.com/dell/dell-csi-extensions/podmon v1.0.0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.0
 	github.com/dell/gocsi v1.6.0
-	github.com/dell/gofsutil v1.9.1-0.20220804050348-2b1cbfd2b12e
+	github.com/dell/gofsutil v1.9.1-0.20220826112338-7e76776fb6cb
 	github.com/dell/goscaleio v1.7.1-0.20220809193611-f43f45ec203c
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.2
@@ -36,7 +37,6 @@ require (
 	github.com/cucumber/gherkin-go/v19 v19.0.3 // indirect
 	github.com/cucumber/messages-go/v16 v16.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dell/dell-csi-extensions/common v1.0.1-0.20220526070836-43b4ac597bf3 // indirect
 	github.com/evanphx/json-patch v4.11.0+incompatible // indirect
 	github.com/go-logr/logr v0.4.0 // indirect
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -125,8 +125,8 @@ github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.0 h1:uFt9JnQ/Wdvka3
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.0/go.mod h1:etLWwS1G2IqHDuArHqB0OWQvpdcztuBxopWrRE+mpk0=
 github.com/dell/gocsi v1.6.0 h1:ZmoMi17v1jK0RE0OGEivu52/RqHbOhP5cqs9SHExqa0=
 github.com/dell/gocsi v1.6.0/go.mod h1:+ihwgNYeFTv69Ym2X2Ij1idK72JYoNR8CeiWYJrrbho=
-github.com/dell/gofsutil v1.9.1-0.20220804050348-2b1cbfd2b12e h1:fw1Es1uTeIQwDdacaf95OsVKg0Bbtb9U6qR1IwQryPM=
-github.com/dell/gofsutil v1.9.1-0.20220804050348-2b1cbfd2b12e/go.mod h1:oebB2eaWWF1jniBQpsMGP6qeZcOPjgeWS0WwShS2KWY=
+github.com/dell/gofsutil v1.9.1-0.20220826112338-7e76776fb6cb h1:hB4ISAHP2lf14j4McCDfB0L4ejzEYdroInTcssVSe2Y=
+github.com/dell/gofsutil v1.9.1-0.20220826112338-7e76776fb6cb/go.mod h1:oebB2eaWWF1jniBQpsMGP6qeZcOPjgeWS0WwShS2KWY=
 github.com/dell/goscaleio v1.7.1-0.20220809193611-f43f45ec203c h1:upBNsXjDfYfJ2meBM+8OVC7Un6lLY4pzx2I6EY/j5EY=
 github.com/dell/goscaleio v1.7.1-0.20220809193611-f43f45ec203c/go.mod h1:TJbQ8N6hk48w5rEyBa+pRtrRJbPVnCTsYM3mmUyPNaY=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=

--- a/overrides.mk
+++ b/overrides.mk
@@ -4,8 +4,8 @@
 
 # DEFAULT values
 DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal"
-# digest for 8.6-902
-DEFAULT_DIGEST="sha256:d1f8eff6032334a81d7cbfd73dacee680e8138db57ecbc91548b97bb45e698e5"
+# digest for 8.6-902.1661794353
+DEFAULT_DIGEST="sha256:c8c1c0f893a7ba679fd65863f2d1389179a92957c31e95521b3290c6b6fc4a76"
 DEFAULT_GOVERSION="1.18.1"
 DEFAULT_REGISTRY="sample_registry"
 DEFAULT_IMAGENAME="csi-vxflexos"

--- a/service/node.go
+++ b/service/node.go
@@ -785,7 +785,7 @@ func (s *service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	Log.Infof("Found %s filesystem mounted on volume %s", fsType, volumePath)
 
 	// Resize the filesystem
-	err = gofsutil.ResizeFS(context.Background(), volumePath, devicePath, "", fsType)
+	err = gofsutil.ResizeFS(context.Background(), volumePath, devicePath, "", "", fsType)
 	if err != nil {
 		Log.Errorf("Failed to resize filesystem: mountpoint (%s) device (%s) with error (%s)",
 			volumePath, devicePath, err.Error())


### PR DESCRIPTION
# Description
Update ubi image to 8.6-902.1661794353 and fsutil to v1.9.1-0.20220826112338-7e76776fb6cb

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/350|

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
