### PR TITLE
Sync VolumeHealthMonitor variable name with other platforms

### DIFF
--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -231,7 +231,7 @@ spec:
             - "--leader-election=true"
             - "--enable-node-watcher=true"
             - "--http-endpoint=:8080"
-            - "--monitor-interval={{ .Values.controller.healthMonitor.volumeHealthMonitorInterval | default "60s" }}"
+            - "--monitor-interval={{ .Values.controller.healthMonitor.interval | default "60s" }}"
             - "--timeout=180s"
           env:
             - name: ADDRESS

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -94,7 +94,7 @@ controller:
     # Allowed values: Number followed by unit (s,m,h)
     # Examples: 60s, 5m, 1h
     # Default value: 60s
-    volumeHealthMonitorInterval: 60s
+    interval: 60s
 
   # volumeNamePrefix- defines a string prepended to each volume created by the CSI driver.
   # Default value: none

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -90,7 +90,7 @@ controller:
     # Default value: None
     enabled: false
 
-    # healthMonitorInterval: Interval of monitoring volume health condition
+    # interval: Interval of monitoring volume health condition
     # Allowed values: Number followed by unit (s,m,h)
     # Examples: 60s, 5m, 1h
     # Default value: 60s


### PR DESCRIPTION
# Description
Change VolumeHealthMonitor variable name to healthMonitor to sync with other platforms

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/203 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Tested VolumeHealthMonitor feature by installing driver and executing 2vols helm test.

Controller pod logs:
![controller-logs](https://user-images.githubusercontent.com/69839943/191929383-da197a47-3ccc-42a9-bb2b-0f3f8557f456.PNG)

Node pod logs:
![node-logs](https://user-images.githubusercontent.com/69839943/191929431-1d9efb0c-9c17-4ca7-b73a-21e860870f68.PNG)
