### PR TITLE
sidecar versions updated

### DIFF
--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v3.5.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.0.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.2.1" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.0.1" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.5.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.6.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.1" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "25") -}}
-      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.6.0" -}}
+      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.7.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
Updated sidecar versions supported in Kubernetes 1.25. 

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/491 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed driver with sidecars and ran cert-csi

	./cert-csi certify --cert-config /root/certify.yaml --vsc vxflexos-snapclass
		[2022-11-16 04:03:04]  INFO Starting cert-csi; ver. 0.8.1
		[2022-11-16 04:03:04]  INFO Suites to run with vxflexos storage class:
		[2022-11-16 04:03:04]  INFO 1. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
		[2022-11-16 04:03:04]  INFO 2. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
		[2022-11-16 04:03:04]  INFO 3. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
		[2022-11-16 04:03:04]  INFO 4. SnapSuite {snapshots: 3, volumeSize; 8Gi}
		[2022-11-16 04:03:04]  INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
		Does it look OK? (Y)es/(n)o
		-> yes
		------------------------------------------------------------------------------------------
		[2022-11-16 04:05:41]  INFO Avg time of a run:   82.82s
		[2022-11-16 04:05:41]  INFO Avg time of a del:   12.81s
		[2022-11-16 04:05:41]  INFO Avg time of all:     100.17s
		[2022-11-16 04:05:41]  INFO During this run 100.0% of suites succeeded