### PR TITLE
Adding the New RHEL Sdc container

### DIFF
--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -10,7 +10,7 @@ images:
   driverRepository: dellemc
 
   # "powerflexSdc" defines the SDC image for init container.
-  powerflexSdc: dellemc/sdc:3.6
+  powerflexSdc: dellemc/sdc:3.6.0.6
 
 
 # Represents number of certificate secrets, which user is going to create for ssl authentication. (vxflexos-cert-0..vxflexos-cert-n)


### PR DESCRIPTION
# Description
With the new release of sdc:3.6.0.6 the automatic sdc installation is now also supported on rhel7.9 and rhel 8.x. 
This pr addressed the changes in the values.yaml for the sdc:3.6.0.6 support in the csi-powerflex driver.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x]  [qualification.txt](https://github.com/dell/csi-powerflex/files/10060038/RHEL7.9-Helm-qualification.txt)

