### PR TITLE
k8s 1.25 verification and update go version in go.mod

### DIFF
--- a/dell-csi-helm-installer/verify-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/verify-csi-vxflexos.sh
@@ -14,7 +14,7 @@
 
 # verify-csi-vxflexos method
 function verify-csi-vxflexos() {
-  verify_k8s_versions "1.21" "1.24"
+  verify_k8s_versions "1.21" "1.25"
   verify_openshift_versions "4.10" "4.11"
   verify_namespace "${NS}"
   verify_helm_values_version "${DRIVER_VERSION}"

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dell/csi-vxflexos/v2
 // In order to run unit tests on Windows, you need a stubbed Windows implementation
 // of the gofsutil package. Use the following replace statements if necessary.
 
-go 1.18
+go 1.19
 
 require (
 	github.com/akutz/memconn v0.1.0

--- a/test/e2e-fsgroup/go.mod
+++ b/test/e2e-fsgroup/go.mod
@@ -1,6 +1,6 @@
 module github.com/dell/csi-powerflex/tests/e2e-fsgroup
 
-go 1.18
+go 1.19
 
 require (
 	github.com/onsi/ginkgo v1.16.5


### PR DESCRIPTION
# Description
Update supported Kubernetes version to 1.25 and update go version in go.mod

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| ---------------- |
| https://github.com/dell/csm/issues/478 |
| https://github.com/dell/csm/issues/491 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] built the image
- [x] Installed the driver on k8s 1.25 setup and verified that test suites ran successfully
[logs.txt](https://github.com/dell/csi-powerflex/files/10065600/logs.txt)


