### PR TITLE
Add Replication CreateRemoteVolume

### DIFF
--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -95,6 +95,19 @@ rules:
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]
     verbs: ["create", "list", "watch", "delete", "update"]
+{{- if hasKey .Values.controller "replication" }}
+{{- if eq .Values.controller.replication.enabled true}}
+  - apiGroups: ["replication.storage.dell.com"]
+    resources: ["dellcsireplicationgroups"]
+    verbs: ["create", "delete", "get", "list", "patch", "update", "watch"]
+  - apiGroups: ["replication.storage.dell.com"]
+    resources: ["dellcsireplicationgroups/status"]
+    verbs: ["get", "patch", "update"]
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+{{- end}}
+{{- end}}
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
@@ -201,6 +214,34 @@ spec:
           volumeMounts:
             - name: socket-dir
               mountPath: /var/run/csi
+        {{- if hasKey .Values.controller "replication" }}
+        {{- if eq .Values.controller.replication.enabled true}}
+        - name: dell-csi-replicator
+          image: {{ required "Must provide the Dell CSI Replicator image." .Values.controller.replication.image}}
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          args:
+            - "--csi-address=$(ADDRESS)"
+            - "--leader-election=true"
+            - "--worker-threads=2"
+            - "--retry-interval-start=1s"
+            - "--retry-interval-max=300s"
+            - "--timeout=300s"
+            - "--context-prefix={{ .Values.controller.replication.replicationContextPrefix}}"
+            - "--prefix={{ .Values.controller.replication.replicationPrefix}}"
+          env:
+            - name: ADDRESS
+              value: /var/run/csi/csi.sock
+            - name: X_CSI_REPLICATION_CONFIG_DIR
+              value: /vxflexos-config-params
+            - name: X_CSI_REPLICATION_CONFIG_FILE_NAME
+              value: driver-config-params.yaml
+          volumeMounts:
+            - name: socket-dir
+              mountPath: /var/run/csi
+            - name: vxflexos-config-params
+              mountPath: /vxflexos-config-params
+        {{- end }}
+        {{- end }}
         - name: provisioner
           image: {{ required "Must provide the CSI provisioner container image." ( include "csi-vxflexos.provisionerImage" . ) }}	
           imagePullPolicy: {{ .Values.imagePullPolicy }}
@@ -339,6 +380,14 @@ spec:
               value: "{{ required "Enable this to have CSI ListVolumes include snapshots" .Values.enablelistvolumesnapshot }}"
             - name: SSL_CERT_DIR
               value: /certs
+            {{- if hasKey .Values.controller "replication" }}
+            {{- if eq .Values.controller.replication.enabled true}}
+            - name: X_CSI_REPLICATION_CONTEXT_PREFIX
+              value: {{ .Values.controller.replication.replicationContextPrefix | default "powerflex"}}
+            - name: X_CSI_REPLICATION_PREFIX
+              value: {{ .Values.controller.replication.replicationPrefix | default "replication.storage.dell.com"}}
+            {{- end }}
+            {{- end }}
             {{- if hasKey .Values.controller "healthMonitor" }}
             {{- if eq .Values.controller.healthMonitor.enabled true}}
             - name: X_CSI_HEALTH_MONITOR_ENABLED

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -82,6 +82,31 @@ fsGroupPolicy: File
 # "controller" allows to configure controller specific parameters
 controller:
 
+  # replication: allows to configure replication
+  # Replication CRDs must be installed before installing driver
+  replication:
+    # enabled: Enable/Disable replication feature
+    # Allowed values:
+    #   true: enable replication feature(install dell-csi-replicator sidecar)
+    #   false: disable replication feature(do not install dell-csi-replicator sidecar)
+    # Default value: false
+    enabled: false
+
+    # image: Image to use for dell-csi-replicator. This shouldn't be changed
+    # Allowed values: string
+    # Default value: None
+    image: dellemc/dell-csi-replicator:v1.3.1
+
+    # replicationContextPrefix: prefix to use for naming of resources created by replication feature
+    # Allowed values: string
+    # Default value: powerflex
+    replicationContextPrefix: "powerflex"
+
+    # replicationPrefix: prefix to prepend to storage classes parameters
+    # Allowed values: string
+    # Default value: replication.storage.dell.com
+    replicationPrefix: "replication.storage.dell.com"
+
   healthMonitor:
     # enabled: Enable/Disable health monitor of CSI volumes
     # Allowed values:

--- a/service/envvars.go
+++ b/service/envvars.go
@@ -51,4 +51,10 @@ const (
 	// EnvIsApproveSDCEnabled is the name of the environment variable that specifies if the SDC approval is to be
 	// carried out or not.
 	EnvIsApproveSDCEnabled = "X_CSI_APPROVE_SDC_ENABLED"
+
+	// EnvReplicationContextPrefix enables sidecars to read required information from volume context
+	EnvReplicationContextPrefix = "X_CSI_REPLICATION_CONTEXT_PREFIX"
+
+	// EnvReplicationPrefix is used as a prefix to find out if replication is enabled
+	EnvReplicationPrefix = "X_CSI_REPLICATION_PREFIX"
 )

--- a/service/features/get_peer_mdms.json
+++ b/service/features/get_peer_mdms.json
@@ -1,0 +1,15 @@
+[
+    {
+      "id": "d02aebc400000000",
+      "name": "10.247.38.62",
+      "port": 7611,
+      "peerSystemId": "15dbbf5617523655",
+      "systemId": "14dbbf5617523654",
+      "softwareVersionInfo": "R3_6.400.0",
+      "membershipState": "Joined",
+      "perfProfile": "HighPerformance",
+      "networkType": "External",
+      "couplingRC": "SUCCESS"
+    }
+  ]
+  

--- a/service/features/get_primary_system_instance.json
+++ b/service/features/get_primary_system_instance.json
@@ -1,0 +1,188 @@
+[
+    {
+      "perfProfile": "Default",
+      "installId": "1c078b073d75512c",
+      "name": "mocksystem",
+      "systemVersionName": "DellEMC ScaleIO Version: R2_6.0.133",
+      "capacityAlertHighThresholdPercent": 80,
+      "capacityAlertCriticalThresholdPercent": 90,
+      "upgradeState": "NoUpgrade",
+      "remoteReadOnlyLimitState": false,
+      "mdmManagementPort": 6611,
+      "sdcMdmNetworkDisconnectionsCounterParameters": {
+        "shortWindow": {
+          "threshold": 300,
+          "windowSizeInSec": 60
+        },
+        "mediumWindow": {
+          "threshold": 500,
+          "windowSizeInSec": 3600
+        },
+        "longWindow": {
+          "threshold": 700,
+          "windowSizeInSec": 86400
+        }
+      },
+      "sdcSdsNetworkDisconnectionsCounterParameters": {
+        "shortWindow": {
+          "threshold": 800,
+          "windowSizeInSec": 60
+        },
+        "mediumWindow": {
+          "threshold": 4000,
+          "windowSizeInSec": 3600
+        },
+        "longWindow": {
+          "threshold": 20000,
+          "windowSizeInSec": 86400
+        }
+      },
+      "sdcMemoryAllocationFailuresCounterParameters": {
+        "shortWindow": {
+          "threshold": 300,
+          "windowSizeInSec": 60
+        },
+        "mediumWindow": {
+          "threshold": 500,
+          "windowSizeInSec": 3600
+        },
+        "longWindow": {
+          "threshold": 700,
+          "windowSizeInSec": 86400
+        }
+      },
+      "sdcSocketAllocationFailuresCounterParameters": {
+        "shortWindow": {
+          "threshold": 300,
+          "windowSizeInSec": 60
+        },
+        "mediumWindow": {
+          "threshold": 500,
+          "windowSizeInSec": 3600
+        },
+        "longWindow": {
+          "threshold": 700,
+          "windowSizeInSec": 86400
+        }
+      },
+      "sdcLongOperationsCounterParameters": {
+        "shortWindow": {
+          "threshold": 10000,
+          "windowSizeInSec": 60
+        },
+        "mediumWindow": {
+          "threshold": 100000,
+          "windowSizeInSec": 3600
+        },
+        "longWindow": {
+          "threshold": 1000000,
+          "windowSizeInSec": 86400
+        }
+      },
+      "cliPasswordAllowed": true,
+      "managementClientSecureCommunicationEnabled": true,
+      "tlsVersion": "TLSv1.2",
+      "showGuid": true,
+      "authenticationMethod": "Native",
+      "mdmToSdsPolicy": "None",
+      "mdmCluster": {
+        "clusterState": "ClusteredNormal",
+        "clusterMode": "ThreeNodes",
+        "master": {
+          "versionInfo": "R2_6.0.0",
+          "managementIPs": [
+            "127.1.1.6"
+          ],
+          "ips": [
+            "127.1.1.6"
+          ],
+          "virtualInterfaces": [],
+          "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+          "role": "Manager",
+          "id": "0873f5bd5c3dd9a1",
+          "port": 9011
+        },
+        "worker": [
+          {
+            "versionInfo": "R2_6.0.0",
+            "managementIPs": [
+              "127.1.1.7"
+            ],
+            "ips": [
+              "127.1.1.7"
+            ],
+            "virtualInterfaces": [],
+            "opensslVersion": "OpenSSL 1.0.2k-fips  26 Jan 2017",
+            "role": "Manager",
+            "status": "Normal",
+            "name": "127.1.1.7",
+            "id": "7e521a811a247d10",
+            "port": 9011
+          }
+        ],
+        "tieBreakers": [
+          {
+            "versionInfo": "R2_6.0.0",
+            "managementIPs": [
+              "127.1.1.8"
+            ],
+            "ips": [
+              "127.1.1.8"
+            ],
+            "opensslVersion": "N/A",
+            "role": "TieBreaker",
+            "status": "Normal",
+            "id": "4542577337090b82",
+            "port": 9011
+          }
+        ],
+        "goodNodesNum": 3,
+        "goodReplicasNum": 2,
+        "id": "1503005277137548884"
+      },
+      "sdcSdsConnectivityInfo": {
+        "sdcSdsConnectivityStatus": "AllConnected",
+        "disconnectedSdcId": null,
+        "disconnectedSdcName": null,
+        "disconnectedSdsId": null,
+        "disconnectedSdsName": null,
+        "disconnectedSdsIp": null
+      },
+      "swid": "",
+      "defaultIsVolumeObfuscated": false,
+      "daysInstalled": 6,
+      "restrictedSdcModeEnabled": false,
+      "restrictedSdcMode": "None",
+      "maxCapacityInGb": "Unlimited",
+      "capacityTimeLeftInDays": "Unlimited",
+      "enterpriseFeaturesEnabled": true,
+      "isInitialLicense": true,
+      "id": "14dbbf5617523654",
+      "links": [
+        {
+          "rel": "self",
+          "href": "/api/instances/System::14dbbf5617523654"
+        },
+        {
+          "rel": "/api/System/relationship/Statistics",
+          "href": "/api/instances/System::14dbbf5617523654/relationships/Statistics"
+        },
+        {
+          "rel": "/api/System/relationship/ProtectionDomain",
+          "href": "/api/instances/System::14dbbf5617523654/relationships/ProtectionDomain"
+        },
+        {
+          "rel": "/api/System/relationship/Sdc",
+          "href": "/api/instances/System::14dbbf5617523654/relationships/Sdc"
+        },
+        {
+          "rel": "/api/System/relationship/User",
+          "href": "/api/instances/System::14dbbf5617523654/relationships/User"
+        }
+      ]
+    }  
+  ]
+  
+  
+  
+  

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -14,3 +14,23 @@ Scenario Outline: Test GetReplicationCapabilities
   | error  | errormsg | valid  |
   | "none" | "none"   | "true" | 
   
+@replication
+Scenario Outline: Test CreateRemoteVolume
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I induce error <error>
+  And I call CreateRemoteVolume
+  Then the error contains <errormsg>
+  Examples:
+  | name        | error                        | errormsg                            |
+  | "sourcevol" | "none"                       | "none"                              |
+  | "sourcevol" | "NoVolIDError"               | "volume ID is required"             |
+  | "sourcevol" | "controller-probe"           | "PodmonControllerProbeError"        |
+  | "sourcevol" | "GetVolByIDError"            | "can't query volume"                |
+  | "sourcevol" | "PeerMdmError"               | "PeerMdmError"                      |
+  | "sourcevol" | "CreateVolumeError"          | "create volume induced error"       |
+  | "sourcevol" | "BadVolIDError"              | "failed to provide"                 |
+  | "sourcevol" | "BadRemoteSystemIDError"     | "System 15dbbf5617523655 not found" |
+  | "sourcevol" | "ProbePrimaryError"          | "PodmonControllerProbeError"        |
+  | "sourcevol" | "ProbeSecondaryError"        | "PodmonControllerProbeError"        |

--- a/service/replication.go
+++ b/service/replication.go
@@ -164,7 +164,7 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 
 	protectionDomain, ok := parameters[s.WithRP(KeyReplicationProtectionDomain)]
 	if !ok {
-		return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no remote protection domain specified in storage class")
+		log.Printf("Remote protection domain not provided; there could be conflicts if two storage pools share a name")
 	}
 
 	name := "replicated-" + vol.Name

--- a/service/replication.go
+++ b/service/replication.go
@@ -1,8 +1,22 @@
 package service
 
 import (
+	"log"
+
+	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/dell-csi-extensions/replication"
 	"golang.org/x/net/context"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+const (
+	// KeyReplicationRemoteSystem represents key for replication remote system
+	KeyReplicationRemoteSystem = "remoteSystem"
+	// KeyReplicationRemoteStoragePool represents key for replication remote storage pool
+	KeyReplicationRemoteStoragePool = "remoteStoragePool"
+	// KeyReplicationProtectionDomain represents key for replication protectionDomain
+	KeyReplicationProtectionDomain = "protectionDomain"
 )
 
 func (s *service) GetReplicationCapabilities(ctx context.Context, req *replication.GetReplicationCapabilityRequest) (*replication.GetReplicationCapabilityResponse, error) {
@@ -87,4 +101,132 @@ func (s *service) GetReplicationCapabilities(ctx context.Context, req *replicati
 		},
 	}
 	return rep, nil
+}
+
+func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.CreateRemoteVolumeRequest) (*replication.CreateRemoteVolumeResponse, error) {
+	Log.Printf("[CreateRemoteVolume] - req %+v", req)
+
+	volHandleCtx := req.GetVolumeHandle()
+	parameters := req.GetParameters()
+
+	if volHandleCtx == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume ID is required")
+	}
+
+	volumeID := getVolumeIDFromCsiVolumeID(volHandleCtx)
+	systemID := s.getSystemIDFromCsiVolumeID(volHandleCtx)
+
+	Log.Printf("Volume ID: %s System ID: %s", volumeID, systemID)
+
+	if volumeID == "" || systemID == "" {
+		return nil, status.Error(codes.InvalidArgument, "failed to provide system ID or volume ID")
+	}
+
+	if err := s.requireProbe(ctx, systemID); err != nil {
+		return nil, err
+	}
+
+	vol, err := s.getVolByID(volumeID, systemID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "can't query volume: %s", err.Error())
+	}
+
+	_, err = s.getSystem(systemID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "could not get (local) system %s: %s", systemID, err.Error())
+	}
+
+	remoteSystemID, ok := parameters[s.WithRP(KeyReplicationRemoteSystem)]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no remote system specified in storage class")
+	}
+
+	// Probe the remote system
+	if err := s.requireProbe(ctx, remoteSystemID); err != nil {
+		Log.Infof("Remote probe failed: %s", err)
+		return nil, err
+	}
+
+	remoteSystem, err := s.getSystem(remoteSystemID)
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = s.getPeerMdms(systemID)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "can't getPeerMDMs: %s", err.Error())
+	}
+
+	remoteStoragePool, ok := parameters[s.WithRP(KeyReplicationRemoteStoragePool)]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no remote storage pool specified in storage class")
+	}
+
+	protectionDomain, ok := parameters[s.WithRP(KeyReplicationProtectionDomain)]
+	if !ok {
+		return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no remote protection domain specified in storage class")
+	}
+
+	name := "replicated-" + vol.Name
+	volReq := createRemoteCreateVolumeRequest(name, remoteStoragePool, remoteSystem.ID, protectionDomain, int64(vol.SizeInKb))
+
+	createVolumeResponse, err := s.CreateVolume(ctx, volReq)
+	if err != nil {
+		log.Printf("CreateVolume called failed: %s", err.Error())
+		return nil, err
+	}
+
+	log.Printf("Potentially created a remote volume: %+v", createVolumeResponse)
+
+	remoteParams := map[string]string{
+		"storagePool":    remoteStoragePool,
+		"remoteSystem":   remoteSystem.ID,
+		"remoteVolumeID": createVolumeResponse.Volume.VolumeId,
+	}
+
+	remoteVolume := getRemoteCSIVolume(createVolumeResponse.GetVolume().VolumeId, vol.SizeInKb)
+	remoteVolume.VolumeContext = remoteParams
+	return &replication.CreateRemoteVolumeResponse{
+		RemoteVolume: remoteVolume,
+	}, nil
+}
+
+// WithRP appends Replication Prefix to provided string
+func (s *service) WithRP(key string) string {
+	return s.opts.replicationPrefix + "/" + key
+}
+
+func createRemoteCreateVolumeRequest(name, storagePool, systemID, protectionDomain string, sizeInKb int64) *csi.CreateVolumeRequest {
+	req := new(csi.CreateVolumeRequest)
+	params := make(map[string]string)
+	params[KeyStoragePool] = storagePool
+	params[KeySystemID] = systemID
+	params[KeyProtectionDomain] = protectionDomain
+	req.Parameters = params
+	req.Name = name
+	capacityRange := new(csi.CapacityRange)
+	capacityRange.RequiredBytes = sizeInKb * 1024
+	req.CapacityRange = capacityRange
+	block := new(csi.VolumeCapability_BlockVolume)
+	capability := new(csi.VolumeCapability)
+	accessType := new(csi.VolumeCapability_Block)
+	accessType.Block = block
+	capability.AccessType = accessType
+	accessMode := new(csi.VolumeCapability_AccessMode)
+	accessMode.Mode = csi.VolumeCapability_AccessMode_SINGLE_NODE_WRITER
+	capability.AccessMode = accessMode
+	capabilities := make([]*csi.VolumeCapability, 0)
+	capabilities = append(capabilities, capability)
+	req.VolumeCapabilities = capabilities
+	return req
+}
+
+func getRemoteCSIVolume(volumeID string, size int) *replication.Volume {
+	volume := &replication.Volume{
+		CapacityBytes: int64(size),
+		VolumeId:      volumeID,
+
+		VolumeContext: nil,
+	}
+	return volume
 }

--- a/service/service.go
+++ b/service/service.go
@@ -881,3 +881,35 @@ func (s *service) getProtectionDomainIDFromName(systemID, protectionDomainName s
 	}
 	return pd.ID, nil
 }
+
+func (s *service) getSystem(systemID string) (*siotypes.System, error) {
+	adminClient := s.adminClients[systemID]
+	if adminClient == nil {
+		return nil, fmt.Errorf("can't find adminClient by id %s", systemID)
+	}
+
+	// Gets the desired system content. Needed for remote replication.
+	systems, err := adminClient.GetSystems()
+	if err != nil {
+		return nil, err
+	}
+	for _, system := range systems {
+		if system.ID == systemID {
+			return system, nil
+		}
+	}
+	return nil, fmt.Errorf("System %s not found", systemID)
+}
+
+func (s *service) getPeerMdms(systemID string) ([]*siotypes.PeerMDM, error) {
+	adminClient := s.adminClients[systemID]
+	if adminClient == nil {
+		return nil, fmt.Errorf("can't find adminClient by id %s", systemID)
+	}
+
+	mdms, err := adminClient.GetPeerMDMs()
+	if err != nil {
+		return nil, err
+	}
+	return mdms, nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -136,6 +136,8 @@ type Opts struct {
 	IsSdcRenameEnabled         bool   // allow driver to enable renaming SDC
 	SdcPrefix                  string // prefix to be set for SDC name
 	IsApproveSDCEnabled        bool
+	replicationContextPrefix   string
+	replicationPrefix          string
 }
 
 type service struct {
@@ -398,6 +400,14 @@ func (s *service) BeforeServe(
 
 	if s.privDir == "" {
 		s.privDir = defaultPrivDir
+	}
+
+	if replicationContextPrefix, ok := csictx.LookupEnv(ctx, EnvReplicationContextPrefix); ok {
+		opts.replicationContextPrefix = replicationContextPrefix + "/"
+	}
+
+	if replicationPrefix, ok := csictx.LookupEnv(ctx, EnvReplicationPrefix); ok {
+		opts.replicationPrefix = replicationPrefix
 	}
 
 	// log csiNode topology keys

--- a/service/service_test.go
+++ b/service/service_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 	opts := godog.Options{
 		Format: "pretty",
 		Paths:  []string{"features"},
-		//Tags:   "wip",
+		// Tags:   "",
 	}
 
 	status := godog.TestSuite{


### PR DESCRIPTION
# Description
Pairing the [implementation ](https://github.com/dell/csi-powerflex/tree/replication)[branch](https://github.com/dell/csi-powerflex/tree/replication-unit-test) with the associated unit-test branch.

Implementation of replication feature within PowerFlex. This brings in the initial call when a replicated volume is to be created on the target array.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Numerous testing has been done to ensure that replication works and is similar and consistent with other drivers.

- [x] Manual testing between two 3.6 PowerFlex arrays.
- [x] Single cluster replication on PowerFlex.
- [x] Multi cluster replication on PowerFlex.
- [x] Cloud -> On-Prem replication on PowerFlex (single/multi cluster).
- [x] `cert-csi` replication testing.

**Note:** Adding local `gosec` results since the github action is failing due to `gosec` update.
![image](https://user-images.githubusercontent.com/7707525/215584506-9c026394-be08-40dc-a20a-d17232c888c8.png)
