### PR TITLE
Add Replication GetStorageProtectionGroupStatus

### DIFF
--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -36,7 +36,7 @@ Scenario Outline: Test CreateRemoteVolume
   | "sourcevol" | "ProbeSecondaryError"        | "PodmonControllerProbeError"        |
 
 
-@replication-wip
+@replication
 Scenario Outline: Test CreateStorageProtectionGroup
   Given a VxFlexOS service
   And I use config "replication-config"
@@ -105,3 +105,39 @@ Scenario Outline: Test multiple CreateStorageProtectionGroup calls
   | name1     | name2     | group name | remote cluster id | rpo  | rpo2   | errormsg |
   | "1srcVol" | "2srcVol" | ""         | "cluster-k211"    | "60" | "60"   | "none"   |
   | "1srcVol" | "2srcVol" | ""         | "cluster-k211"    | "60" | "120"  | "none"   |
+
+@replication
+Scenario Outline: Test GetStorageProtectionGroupStatus 
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I induce error <error>
+  And I call GetStorageProtectionGroupStatus
+  Then the error contains <errormsg>
+
+  Examples:
+  | name        | error                     | errormsg                                           |
+  | "sourcevol" | "none"                    | "none"                                             |
+  | "sourcevol" | "GetRCGByIdError"         | "could not GET RCG by ID"                          |
+  | "sourcevol" | "GetReplicationPairError" | "GET ReplicationPair induced error"                |
+
+@replication
+Scenario Outline: Test GetStorageProtectionGroupStatus current status
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I call GetStorageProtectionGroupStatus with state <state> and mode <mode>
+  Then the error contains <errormsg>
+
+  Examples:
+  | name        | errormsg   | state       | mode                  |
+  | "sourcevol" | "none"     | "Normal"    | "Consistent"          |
+  | "sourcevol" | "none"     | "Normal"    | "PartiallyConsistent" |
+  | "sourcevol" | "none"     | "Normal"    | "ConsistentPending"   |
+  | "sourcevol" | "none"     | "Normal"    | "Invalid"             |
+  | "sourcevol" | "none"     | "Failover"  | "Consistent"          |
+  | "sourcevol" | "none"     | "Paused"    | "Consistent"          |

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3523,6 +3523,39 @@ func (f *feature) iCallCreateStorageProtectionGroupWith(arg1, arg2, arg3 string)
 	return nil
 }
 
+func (f *feature) iCallGetStorageProtectionGroupStatus() error {
+	ctx := new(context.Context)
+	attributes := make(map[string]string)
+
+	replicationGroupConsistMode = defaultConsistencyMode
+
+	attributes[f.service.opts.replicationContextPrefix+"systemName"] = arrayID
+	req := &replication.GetStorageProtectionGroupStatusRequest{
+		ProtectionGroupId:         f.createStorageProtectionGroupResponse.LocalProtectionGroupId,
+		ProtectionGroupAttributes: attributes,
+	}
+	_, f.err = f.service.GetStorageProtectionGroupStatus(*ctx, req)
+
+	return nil
+}
+
+func (f *feature) iCallGetStorageProtectionGroupStatusWithStateAndMode(arg1, arg2 string) error {
+	ctx := new(context.Context)
+	attributes := make(map[string]string)
+
+	replicationGroupState = arg1
+	replicationGroupConsistMode = arg2
+
+	attributes[f.service.opts.replicationContextPrefix+"systemName"] = arrayID
+	req := &replication.GetStorageProtectionGroupStatusRequest{
+		ProtectionGroupId:         f.createStorageProtectionGroupResponse.LocalProtectionGroupId,
+		ProtectionGroupAttributes: attributes,
+	}
+	_, f.err = f.service.GetStorageProtectionGroupStatus(*ctx, req)
+
+	return nil
+}
+
 func FeatureContext(s *godog.ScenarioContext) {
 	f := &feature{}
 	s.Step(`^a VxFlexOS service$`, f.aVxFlexOSService)
@@ -3687,6 +3720,8 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I call CreateRemoteVolume$`, f.iCallCreateRemoteVolume)
 	s.Step(`^I call CreateStorageProtectionGroup$`, f.iCallCreateStorageProtectionGroup)
 	s.Step(`^I call CreateStorageProtectionGroup with "([^"]*)", "([^"]*)", "([^"]*)"$`, f.iCallCreateStorageProtectionGroupWith)
+	s.Step(`^I call GetStorageProtectionGroupStatus$`, f.iCallGetStorageProtectionGroupStatus)
+	s.Step(`^I call GetStorageProtectionGroupStatus with state "([^"]*)" and mode "([^"]*)"$`, f.iCallGetStorageProtectionGroupStatusWithStateAndMode)
 
 	s.After(func(ctx context.Context, sc *godog.Scenario, err error) (context.Context, error) {
 		if f.server != nil {

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -24,6 +24,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/dell/goscaleio"
 	types "github.com/dell/goscaleio/types/v1"
 	"github.com/gorilla/mux"
 	codes "google.golang.org/grpc/codes"
@@ -108,6 +109,7 @@ const (
 	remoteRCGID            = "d303184900000001"
 	unmarkedForReplication = "UnmarkedForReplication"
 	defaultVolumeSize      = "33554432"
+	defaultConsistencyMode = goscaleio.Consistent
 )
 
 // getFileHandler returns an http.Handler that


### PR DESCRIPTION
# Description
Pairing the [implementation ](https://github.com/dell/csi-powerflex/tree/replication)[branch](https://github.com/dell/csi-powerflex/tree/replication-unit-test) with the associated unit-test branch.

Adds the implementation of retrieving the status of the storage protection from the PowerFlex arrays. This is used to display on the replication CRD the status of the RGs.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Numerous testing has been done to ensure that replication works and is similar and consistent with other drivers.

- [x] Manual testing between two 3.6 PowerFlex arrays.
- [x] Single cluster replication on PowerFlex.
- [x] Multi cluster replication on PowerFlex.
- [x] Cloud -> On-Prem replication on PowerFlex (single/multi cluster).
- [x] `cert-csi` replication testing.
