### PR TITLE
Add Replication DeleteStorageProtectionGroup

### DIFF
--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -141,3 +141,41 @@ Scenario Outline: Test GetStorageProtectionGroupStatus current status
   | "sourcevol" | "none"     | "Normal"    | "Invalid"             |
   | "sourcevol" | "none"     | "Failover"  | "Consistent"          |
   | "sourcevol" | "none"     | "Paused"    | "Consistent"          |
+
+@replication
+Scenario Outline: Test DeleteStorageProtectionGroup up to volume
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I induce error <error>
+  And I call DeleteVolume <name>
+  Then the error contains <errormsg>
+
+  Examples:
+  | name        | error                                       | errormsg                                           |
+  | "sourcevol" | "none"                                      | "none"                                             |
+  | "sourcevol" | "NoDeleteReplicationPair"                   | "pairs exist"                                      |
+  | "sourcevol" | "ReplicationPairAlreadyExistsUnretrievable" | "error removing replication pair"                  |
+  | "sourcevol" | "GetReplicationPairError"                   | "GET ReplicationPair induced error"                |
+
+@replication
+Scenario Outline: Test DeleteStorageProtectionGroup 
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I call DeleteVolume <name>
+  And I induce error <error>
+  And I call DeleteStorageProtectionGroup
+  Then the error contains <errormsg>
+
+  Examples:
+  | name        | error                                 | errormsg                                           |
+  | "sourcevol" | "none"                                | "none"                                             |
+  | "sourcevol" | "GetReplicationPairError"             | "GET ReplicationPair induced error"                |
+  | "sourcevol" | "ReplicationGroupAlreadyDeleted"      | "none"                                             |
+  | "sourcevol" | "GetRCGByIdError"                     | "could not GET RCG by ID"                          |
+  | "sourcevol" | "RemoveRCGError"                      | "coule not remove RCG"                             |

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -702,6 +702,24 @@ func handleAction(w http.ResponseWriter, r *http.Request) {
 		_ = decoder.Decode(&req)
 		fmt.Printf("set volume name %s", req.NewName)
 		volumeIDToName[id] = req.NewName
+	case "removeReplicationConsistencyGroup":
+		if inducedError.Error() == "RemoveRCGError" {
+			writeError(w, "coule not remove RCG", http.StatusRequestTimeout, codes.Internal)
+			return
+		}
+
+		groups := systemArrays[r.Host].replicationConsistencyGroups
+		delete(groups, id)
+
+	case "removeReplicationPair":
+		if inducedError.Error() == "NoDeleteReplicationPair" {
+			writeError(w, "pairs exist", http.StatusRequestTimeout, codes.Internal)
+			return
+		}
+		pairs := systemArrays[r.Host].replicationPairs
+		delete(pairs, id)
+
+		fmt.Printf("volumeIDToReplicationState %+v\n", volumeIDToReplicationState)
 	}
 }
 


### PR DESCRIPTION
# Description
Pairing the [implementation ](https://github.com/dell/csi-powerflex/tree/replication)[branch](https://github.com/dell/csi-powerflex/tree/replication-unit-test) with the associated unit-test branch.

Adds the implementation of deleting the replication consistency group from the PowerFlex array. Ensures that all replication pairs must be deleted prior to successfully deleting the replication consistency group.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Numerous testing has been done to ensure that replication works and is similar and consistent with other drivers.

- [x] Manual testing between two 3.6 PowerFlex arrays.
- [x] Single cluster replication on PowerFlex.
- [x] Multi cluster replication on PowerFlex.
- [x] Cloud -> On-Prem replication on PowerFlex (single/multi cluster).
- [x] `cert-csi` replication testing.
