### PR TITLE
Add Replicaiton ExecuteAction

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20221019160525-ed5b353790e7
 	github.com/dell/gocsi v1.6.0
 	github.com/dell/gofsutil v1.11.0
-	github.com/dell/goscaleio v1.9.1-0.20230203130415-4484a6d0eaef
+	github.com/dell/goscaleio v1.9.1-0.20230210195957-57ee14d5f084
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.2
 	github.com/gorilla/mux v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -135,6 +135,8 @@ github.com/dell/goscaleio v1.9.1-0.20230202110014-f23fa6750e91 h1:qMuLcx009Nu1Wz
 github.com/dell/goscaleio v1.9.1-0.20230202110014-f23fa6750e91/go.mod h1:f+OsYKdKJc8j/a0uHI6nJZpiMfx7wDd6yq78dAeBHsg=
 github.com/dell/goscaleio v1.9.1-0.20230203130415-4484a6d0eaef h1:16ArpQKe24VGb+LuFaWF2OxzudhrDuutf+qbFb2PH8I=
 github.com/dell/goscaleio v1.9.1-0.20230203130415-4484a6d0eaef/go.mod h1:f+OsYKdKJc8j/a0uHI6nJZpiMfx7wDd6yq78dAeBHsg=
+github.com/dell/goscaleio v1.9.1-0.20230210195957-57ee14d5f084 h1:1JT1VNhTc+puPcEWyx1vCiFao2ZonqC1P7kWacU+dQ4=
+github.com/dell/goscaleio v1.9.1-0.20230210195957-57ee14d5f084/go.mod h1:f+OsYKdKJc8j/a0uHI6nJZpiMfx7wDd6yq78dAeBHsg=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/service/controller.go
+++ b/service/controller.go
@@ -2495,3 +2495,74 @@ func (s *service) DeleteReplicationConsistencyGroup(systemID string, groupID str
 
 	return err
 }
+
+func (s *service) CreateReplicationConsistencyGroupSnapshot(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup) (*siotypes.CreateReplicationConsistencyGroupSnapshotResp, error) {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	response, err := rcg.CreateReplicationConsistencyGroupSnapshot(false)
+	if err != nil {
+		return nil, err
+	}
+
+	return response, nil
+}
+
+func (s *service) ExecuteFailoverOnReplicationGroup(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup) error {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	Log.Printf("[ExecuteFailoverOnReplicationGroup]: Executing Failover command")
+
+	return rcg.ExecuteFailoverOnReplicationGroup()
+}
+
+func (s *service) ExecuteSwitchoverOnReplicationGroup(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup) error {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	Log.Printf("[ExecuteSwitchoverOnReplicationGroup]: Executing Switchover (Unplanned Failover)")
+
+	return rcg.ExecuteSwitchoverOnReplicationGroup(false)
+}
+
+func (s *service) ExecuteReverseOnReplicationGroup(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup) error {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	Log.Printf("[ExecuteReverseOnReplicationGroup]: Executing Reverse (Reprotect Local)")
+
+	return rcg.ExecuteReverseOnReplicationGroup()
+}
+
+func (s *service) ExecuteResumeOnReplicationGroup(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup, failover bool) error {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	Log.Printf("[ExecuteReverseOnReplicationGroup]: Resuming Replication Group")
+
+	if failover {
+		Log.Printf("[ExecuteReverseOnReplicationGroup]: In Failover, Restoring...")
+		return rcg.ExecuteRestoreOnReplicationGroup()
+	}
+
+	return rcg.ExecuteResumeOnReplicationGroup()
+}
+
+func (s *service) ExecutePauseOnReplicationGroup(client *goscaleio.Client, group *siotypes.ReplicationConsistencyGroup) error {
+	rcg := goscaleio.NewReplicationConsistencyGroup(client)
+	rcg.ReplicationConsistencyGroup = group
+
+	Log.Printf("[ExecutePauseOnReplicationGroup]: Pause Replication Group")
+
+	return rcg.ExecutePauseOnReplicationGroup()
+}
+
+func (s *service) verifySystem(systemID string) (*goscaleio.Client, error) {
+	adminClient := s.adminClients[systemID]
+	if adminClient == nil {
+		return nil, fmt.Errorf("can't find adminClient by id %s", systemID)
+	}
+
+	return adminClient, nil
+}

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -179,3 +179,33 @@ Scenario Outline: Test DeleteStorageProtectionGroup
   | "sourcevol" | "ReplicationGroupAlreadyDeleted"      | "none"                                             |
   | "sourcevol" | "GetRCGByIdError"                     | "could not GET RCG by ID"                          |
   | "sourcevol" | "RemoveRCGError"                      | "coule not remove RCG"                             |
+
+@replication
+Scenario Outline: Test ExecuteAction
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I call GetStorageProtectionGroupStatus with state <state> and mode <mode>
+  And I induce error <error>
+  And I call ExecuteAction <action>
+  Then the error contains <errormsg>
+
+  Examples:
+  | name        | error                     | errormsg                            | action              |  state      | mode          |
+  | "sourcevol" | "none"                    | "none"                              | "CreateSnapshot"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "CreateSnapshot"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "SnapshotCreationError"   | "RCG snapshot not created"          | "CreateSnapshot"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "FailoverRemote"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "FailoverRemote"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "UnplannedFailover" | "Normal"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "UnplannedFailover" | "Normal"    | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "ReprotectLocal"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "ReprotectLocal"    | "Normal"    | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "Resume"            | "Failover"  | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "Resume"            | "Paused"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "Resume"            | "Failover"  | "Consistent"  |
+  | "sourcevol" | "none"                    | "none"                              | "Suspend"           | "Normal"    | "Consistent"  |
+  | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "Suspend"           | "Normal"    | "Consistent"  |
+  | "sourcevol" | "none"                    | "not match with supported actions"  | "Unknown"           | "Normal"    | "Consistent"  |


### PR DESCRIPTION
# Description
Pairing the [implementation ](https://github.com/dell/csi-powerflex/tree/replication)[branch](https://github.com/dell/csi-powerflex/tree/replication-unit-test) with the associated unit-test branch.

Adds the implementation of executing all the replication actions supported natively by the PowerFlex array.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Numerous testing has been done to ensure that replication works and is similar and consistent with other drivers.

- [x] Manual testing between two 3.6 PowerFlex arrays.
- [x] Single cluster replication on PowerFlex.
- [x] Multi cluster replication on PowerFlex.
- [x] Cloud -> On-Prem replication on PowerFlex (single/multi cluster).
- [x] `cert-csi` replication testing.
