### PR TITLE
Add Replication ExpandVolume

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/common v1.1.1-0.20221019160525-ed5b353790e7
 	github.com/dell/dell-csi-extensions/podmon v1.1.2-0.20221019160525-ed5b353790e7
-	github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112201116-67291a77b976
+	github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230208231315-3fa5be96edff
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20221019160525-ed5b353790e7
 	github.com/dell/gocsi v1.6.0
 	github.com/dell/gofsutil v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -123,6 +123,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2-0.20221019160525-ed5b353790e7 
 github.com/dell/dell-csi-extensions/podmon v1.1.2-0.20221019160525-ed5b353790e7/go.mod h1:J4VNEmXV6sz40QviNF1B+Ov+KNQmzFtJw0YNUpq6ncs=
 github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112201116-67291a77b976 h1:+7blNqXuHA7KxnDF54hPntUiTOaZNE5Bd3f/e2Zt8hg=
 github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230112201116-67291a77b976/go.mod h1:FU2kzS8/29GlK9iCdS+E70cyeWun63eNP44aHwg7jW8=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230208231315-3fa5be96edff h1:U1/f9Z9etlfLd6pvCOW6hUT9nXN8c6VYXLetveGh58c=
+github.com/dell/dell-csi-extensions/replication v1.2.2-0.20230208231315-3fa5be96edff/go.mod h1:QODGw6pqNG0YysOPHg2RgB3rFWGLWCSlq8i25CEvEVk=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20221019160525-ed5b353790e7 h1:xl9qR/Bjv8GR7gCybqoYkfB39TcSLGcYJqjMAG6qCdc=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2-0.20221019160525-ed5b353790e7/go.mod h1:etLWwS1G2IqHDuArHqB0OWQvpdcztuBxopWrRE+mpk0=
 github.com/dell/gocsi v1.6.0 h1:ZmoMi17v1jK0RE0OGEivu52/RqHbOhP5cqs9SHExqa0=

--- a/helm/csi-vxflexos/templates/controller.yaml
+++ b/helm/csi-vxflexos/templates/controller.yaml
@@ -106,6 +106,9 @@ rules:
   - apiGroups: [""]
     resources: ["configmaps"]
     verbs: ["create", "delete", "get", "list", "watch", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["namespaces"]
+    verbs: ["create", "get", "list", "watch"]
 {{- end}}
 {{- end}}
 ---

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -95,7 +95,7 @@ controller:
     # image: Image to use for dell-csi-replicator. This shouldn't be changed
     # Allowed values: string
     # Default value: None
-    image: dellemc/dell-csi-replicator:v1.3.1
+    image: dellemc/dell-csi-replicator:v1.4.0
 
     # replicationContextPrefix: prefix to use for naming of resources created by replication feature
     # Allowed values: string

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -209,3 +209,20 @@ Scenario Outline: Test ExecuteAction
   | "sourcevol" | "none"                    | "none"                              | "Suspend"           | "Normal"    | "Consistent"  |
   | "sourcevol" | "ExecuteActionError"      | "could not execute RCG action"      | "Suspend"           | "Normal"    | "Consistent"  |
   | "sourcevol" | "none"                    | "not match with supported actions"  | "Unknown"           | "Normal"    | "Consistent"  |
+
+@replication
+Scenario Outline: Test ControllerExpandVolume on replication pair
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I induce error <error>
+  Then I call ControllerExpandVolume set to <GB>
+  Then the error contains <errormsg>
+
+  Examples:
+  | name      | GB | error                     | errormsg                            |
+  | "1srcVol" | 64 | "none"                    | "none"                              |
+  | "1srcVol" | 64 | "GetReplicationPairError" | "GET ReplicationPair induced error" |
+  | "1srcVol" | 64 | "GetRCGByIdError"         | "could not GET RCG by ID"           |

--- a/service/replication.go
+++ b/service/replication.go
@@ -602,7 +602,7 @@ func (s *service) getReplicationConsistencyGroupByID(systemID string, groupID st
 	return group, nil
 }
 
-func (s *service) createUniqueConsistencyGroupName(systemID, remoteSystemId, rpo, localPd, remotePd, remoteClusterID, clusterUID, rcgPrefix string) (string, error) {
+func (s *service) createUniqueConsistencyGroupName(systemID, remoteSystemID, rpo, localPd, remotePd, remoteClusterID, clusterUID, rcgPrefix string) (string, error) {
 	consistencyGroupName := rcgPrefix + "-"
 	clusterUID = strings.Replace(clusterUID, "-", "", -1)
 	remoteClusterID = strings.Replace(remoteClusterID, "-", "", -1)

--- a/service/replication.go
+++ b/service/replication.go
@@ -30,6 +30,8 @@ const (
 	KeyReplicationRPO = "rpo"
 	// KeyReplicationClusterID represents key for replication remote cluster ID
 	KeyReplicationClusterID = "remoteClusterID"
+	// KeyReplicationVGPrefix represents key for replication vg prefix
+	KeyReplicationVGPrefix = "volumeGroupPrefix"
 
 	sioReplicationPairsDoesNotExist = "Error in get relationship ReplicationPair"
 	sioReplicationGroupNotFound     = "The Replication Consistency Group was not found"
@@ -284,11 +286,18 @@ func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replica
 
 		clusterUID, ok := parameters["clusterUID"]
 		if !ok {
-			return nil, status.Errorf(codes.InvalidArgument, "replication enabled but no source cluster UID retrieved")
+			Log.Warnf("[CreateStorageProtectionGroup] - source cluster UID not provided, using remote system ID in RCG name.")
+			clusterUID = remoteSystemID
+		}
+
+		rcgPrefix, ok := parameters[s.WithRP(KeyReplicationVGPrefix)]
+		if !ok || rcgPrefix == "" {
+			Log.Warnf("[CreateStorageProtectionGroup] - RCG prefix not provided, using 'RCG' as prefix.")
+			rcgPrefix = "rcg"
 		}
 
 		consistencyGroupName, err = s.createUniqueConsistencyGroupName(systemID, remoteSystemID, rpo,
-			localProtectionDomain, remoteProtectionDomain, remoteClusterID, clusterUID)
+			localProtectionDomain, remoteProtectionDomain, remoteClusterID, clusterUID, rcgPrefix)
 		if err != nil {
 			return nil, err
 		}
@@ -593,16 +602,14 @@ func (s *service) getReplicationConsistencyGroupByID(systemID string, groupID st
 	return group, nil
 }
 
-func (s *service) createUniqueConsistencyGroupName(systemID, remoteSystemID, rpo, localPd, remotePd, remoteClusterID, clusterUID string) (string, error) {
-	var consistencyGroupName string
+func (s *service) createUniqueConsistencyGroupName(systemID, remoteSystemId, rpo, localPd, remotePd, remoteClusterID, clusterUID, rcgPrefix string) (string, error) {
+	consistencyGroupName := rcgPrefix + "-"
 	clusterUID = strings.Replace(clusterUID, "-", "", -1)
 	remoteClusterID = strings.Replace(remoteClusterID, "-", "", -1)
 
 	if remoteClusterID == "self" {
-		consistencyGroupName += "rcg-"
 		consistencyGroupName += clusterUID[:6] + "-v"
 	} else {
-		consistencyGroupName += "rcg-"
 		remoteClusterID = strings.ReplaceAll(remoteClusterID, "cluster", "")
 
 		if len(remoteClusterID) > 7 {

--- a/service/service.go
+++ b/service/service.go
@@ -31,6 +31,7 @@ import (
 	"github.com/dell/csi-vxflexos/v2/core"
 	"github.com/dell/csi-vxflexos/v2/k8sutils"
 	"github.com/dell/dell-csi-extensions/podmon"
+	"github.com/dell/dell-csi-extensions/replication"
 	volumeGroupSnapshot "github.com/dell/dell-csi-extensions/volumeGroupSnapshot"
 	"github.com/dell/gocsi"
 	csictx "github.com/dell/gocsi/context"
@@ -476,6 +477,7 @@ func (s *service) RegisterAdditionalServers(server *grpc.Server) {
 	Log.Info("Registering additional GRPC servers")
 	podmon.RegisterPodmonServer(server, s)
 	volumeGroupSnapshot.RegisterVolumeGroupSnapshotServer(server, s)
+	replication.RegisterReplicationServer(server, s)
 }
 
 // getVolProvisionType returns a string indicating thin or thick provisioning

--- a/service/service.go
+++ b/service/service.go
@@ -988,3 +988,52 @@ func (s *service) findReplicationPairByVolID(systemID, volumeID string) (*siotyp
 
 	return nil, fmt.Errorf("replication pair for volume ID: %s, not found", volumeID)
 }
+
+func (s *service) expandReplicationPair(ctx context.Context, req *csi.ControllerExpandVolumeRequest, systemID, volumeID string) error {
+	Log.Printf("[expandReplicationPair] - Start: %s, %s", systemID, volumeID)
+	pair, err := s.findReplicationPairByVolID(systemID, volumeID)
+	if err != nil {
+		return err
+	}
+
+	Log.Printf("[expandReplicationPair] - Pair Found: %+v", pair)
+	group, err := s.getReplicationConsistencyGroupByID(systemID, pair.ReplicationConsistencyGroupID)
+	if err != nil {
+		return err
+	}
+
+	Log.Printf("[expandReplicationPair] - Group Found: %+v", group)
+	// Avoid getting in a expand attempt cycle.
+	if group.ReplicationDirection == "RemoteToLocal" {
+		Log.Printf("[expandReplicationPair] - Only want to expand from LocalToRemote, if first call, there might be an issue.")
+		return nil
+	}
+
+	req.VolumeId = group.RemoteMdmID + "-" + pair.RemoteVolumeID
+
+	resp, err := s.ControllerExpandVolume(ctx, req)
+	if err != nil {
+		return err
+	}
+
+	Log.Printf("[expandReplicationPair] - ControllerExpandVolume expanded the remote volume first: %+v", resp)
+	Log.Printf("[expandReplicationPair] - Ensuring remote has expanded...")
+
+	requestedSize, err := validateVolSize(req.CapacityRange)
+	if err != nil {
+		return err
+	}
+
+	vol, _ := s.getVolByID(volumeID, systemID)
+
+	attempts := 0
+	maxVolRetrievalRetries := 100
+
+	for int64(vol.SizeInKb) != requestedSize && attempts < maxVolRetrievalRetries {
+		time.Sleep(3 * time.Millisecond)
+		vol, _ = s.getVolByID(volumeID, systemID)
+		attempts++
+	}
+
+	return nil
+}


### PR DESCRIPTION
# Description
Pairing the [implementation ](https://github.com/dell/csi-powerflex/tree/replication)[branch](https://github.com/dell/csi-powerflex/tree/replication-unit-test) with the associated unit-test branch.

Adds the implementation of expanding a replicated volume.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Numerous testing has been done to ensure that replication works and is similar and consistent with other drivers.

- [x] Manual testing between two 3.6 PowerFlex arrays.
- [x] Single cluster replication on PowerFlex.
- [x] Multi cluster replication on PowerFlex.
- [x] Cloud -> On-Prem replication on PowerFlex (single/multi cluster).
- [x] `cert-csi` replication testing.
