### PR TITLE
go version updated to 1.20

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/dell/csi-vxflexos/v2
 // In order to run unit tests on Windows, you need a stubbed Windows implementation
 // of the gofsutil package. Use the following replace statements if necessary.
 
-go 1.19
+go 1.20
 
 require (
 	github.com/akutz/memconn v0.1.0

--- a/overrides.mk
+++ b/overrides.mk
@@ -6,7 +6,7 @@
 DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal"
 # digest for 8.6-994
 DEFAULT_DIGEST="sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45"
-DEFAULT_GOVERSION="1.19.2"
+DEFAULT_GOVERSION="1.20"
 DEFAULT_REGISTRY="sample_registry"
 DEFAULT_IMAGENAME="csi-vxflexos"
 DEFAULT_BUILDSTAGE="final"


### PR DESCRIPTION
# Description
Updated golang version to 1.20.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/658 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the driver with the new image built with go 1.20 and executed cert-csi.
```
[root@master-1-ytIuu2Xkibg1Q ~]# ./cert-csi certify --cert-config certify.yaml --vsc vxflexos-snapclass
[2023-02-21 01:00:40]  INFO Starting cert-csi; ver. 0.8.1
[2023-02-21 01:00:40]  INFO Suites to run with vxflexos storage class:
[2023-02-21 01:00:40]  INFO 1. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
[2023-02-21 01:00:40]  INFO 2. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
[2023-02-21 01:00:40]  INFO 3. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
[2023-02-21 01:00:40]  INFO 4. SnapSuite {snapshots: 3, volumeSize; 8Gi}
[2023-02-21 01:00:40]  INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
Does it look OK? (Y)es/(n)o
-> yes
.
.
.
[2023-02-21 01:07:17]  INFO Avg time of a run:   61.42s
[2023-02-21 01:07:17]  INFO Avg time of a del:   14.29s
[2023-02-21 01:07:17]  INFO Avg time of all:     78.71s
[2023-02-21 01:07:17]  INFO During this run 100.0% of suites succeeded

```