### PR TITLE
update the ubi image to latest.

### DIFF
--- a/overrides.mk
+++ b/overrides.mk
@@ -4,8 +4,8 @@
 
 # DEFAULT values
 DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal"
-# digest for 8.6-994
-DEFAULT_DIGEST="sha256:c5ffdf5938d73283cec018f2adf59f0ed9f8c376d93e415a27b16c3c6aad6f45"
+# digest for  8.7-1049.1675784874
+DEFAULT_DIGEST="sha256:0214a28336e387c66493c61bb394e86a18f3bea8dbc46de74a26f173ff553c89"
 DEFAULT_GOVERSION="1.20"
 DEFAULT_REGISTRY="sample_registry"
 DEFAULT_IMAGENAME="csi-vxflexos"


### PR DESCRIPTION
# Description
This pr will update the redhat ubi base image  for csi-powerflex to latest(8.7-1049.1675784874)

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Build the csi-vxflexos image with the new ubi-image and installed the csi-vxflexos driver. The driver installation is successful
- [x] Ran Sanity test to verify everything is working fine.
![cert-csi-result](https://user-images.githubusercontent.com/103578883/221771869-db541557-8042-4338-b7fd-164d30ce7694.PNG)
