### PR TITLE
Fix Failover State Reporting

### DIFF
--- a/service/replication.go
+++ b/service/replication.go
@@ -682,7 +682,7 @@ func (s *service) getReplicationPairs(systemID string, groupID string) ([]*sioty
 }
 
 func isFailover(group *siotypes.ReplicationConsistencyGroup) bool {
-	return group.FailoverType != "None" && group.FailoverState == "Done"
+	return group.FailoverType != "None"
 }
 
 func isPaused(group *siotypes.ReplicationConsistencyGroup) bool {


### PR DESCRIPTION
# Description
During testing, it was identified that we were short-circuiting the Failover reporting status. The `failoverType` was still set but the `failoverState` was not set to `Done`. 

To avoid incorrect `Failover`, we are just checking to see if the `failoverType` is set.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/618 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Automation testing through the pipeline.
