### PR TITLE
update ubi image to 8.7-1085.

### DIFF
--- a/overrides.mk
+++ b/overrides.mk
@@ -4,8 +4,8 @@
 
 # DEFAULT values
 DEFAULT_BASEIMAGE="registry.access.redhat.com/ubi8/ubi-minimal"
-# digest for  8.7-1049.1675784874
-DEFAULT_DIGEST="sha256:0214a28336e387c66493c61bb394e86a18f3bea8dbc46de74a26f173ff553c89"
+# digest for 8.7-1085
+DEFAULT_DIGEST="sha256:ab03679e683010d485ef0399e056b09a38d7843ba4a36ee7dec337dd0037f7a7"
 DEFAULT_GOVERSION="1.20"
 DEFAULT_REGISTRY="sample_registry"
 DEFAULT_IMAGENAME="csi-vxflexos"


### PR DESCRIPTION
# Description
This pr updates the redhat ubi base image to 8.7-1085

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Build the csi-vxflexos image with the new ubi-image and installed the csi-vxflexos driver. The driver installation is successful
- [x] Ran Sanity test to verify everything is working fine.
 
![cert-csi-result](https://user-images.githubusercontent.com/103578883/222336330-5976eb16-ee35-49ab-9e82-243065bdc5b6.PNG)
