### PR TITLE
update sidecar versions

### DIFF
--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.0.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-attacher:v4.2.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.3.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-provisioner:v3.4.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.1.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-snapshotter:v6.2.1" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.6.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-resizer:v1.7.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.0" -}}
+      {{- print "k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "26") -}}
-      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.7.0" -}}
+      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
Updated the sidecar versions used for the driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| https://github.com/dell/csm/issues/583 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed driver with sidecars, described the pods to check and verify the versions
<img width="792" alt="sidecarupdimg1" src="https://user-images.githubusercontent.com/110008193/222464885-501e772e-9068-4bd6-ab11-857a88fce784.png">
<img width="629" alt="sidecarupdimg2" src="https://user-images.githubusercontent.com/110008193/222464935-8a8ccdce-dcb1-4ee4-9a09-c16a2cf90cbf.png">
<img width="758" alt="3" src="https://user-images.githubusercontent.com/110008193/222466106-325009fb-021c-4649-b1d4-4c579c6fd39e.png">
<img width="583" alt="4" src="https://user-images.githubusercontent.com/110008193/222470338-872b5f82-3dab-457e-98ec-872ed7d48068.png">

- [x] Ran cert csi test suites
`./cert-csi certify --cert-config /root/csm-pipeline/csm-config/drivers/powerflex/tests/certify.yaml --vsc vxflexos-snapclass
[2023-03-02 07:15:44]  INFO Starting cert-csi; ver. 0.8.1
[2023-03-02 07:15:44]  INFO Suites to run with vxflexos storage class:
[2023-03-02 07:15:44]  INFO 1. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
[2023-03-02 07:15:44]  INFO 2. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
[2023-03-02 07:15:44]  INFO 3. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
[2023-03-02 07:15:44]  INFO 4. SnapSuite {snapshots: 3, volumeSize; 8Gi}
[2023-03-02 07:15:44]  INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
Does it look OK? (Y)es/(n)o
-> y

[2023-03-02 07:17:20]  INFO Avg time of a run:   53.92s
[2023-03-02 07:17:20]  INFO Avg time of a del:   13.13s
[2023-03-02 07:17:20]  INFO Avg time of all:     70.38s
[2023-03-02 07:17:20]  INFO During this run 100.0% of suites succeeded`