### PR TITLE
Added stub for new DeleteLocalVolume gRPC call

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.0
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0

--- a/go.mod
+++ b/go.mod
@@ -11,13 +11,13 @@ require (
 	github.com/cucumber/godog v0.12.1
 	github.com/dell/dell-csi-extensions/common v1.1.1
 	github.com/dell/dell-csi-extensions/podmon v1.1.2
-	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0
+	github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230330153121-7ee6c5ed22ea
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
 	github.com/dell/goscaleio v1.10.0
 	github.com/fsnotify/fsnotify v1.5.1
-	github.com/golang/protobuf v1.5.2
+	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/mux v1.8.0
 	github.com/kubernetes-csi/csi-lib-utils v0.9.1
@@ -25,7 +25,7 @@ require (
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/net v0.8.0
-	google.golang.org/grpc v1.53.0
+	google.golang.org/grpc v1.54.0
 	k8s.io/api v0.22.2
 	k8s.io/apimachinery v0.22.2
 	k8s.io/client-go v0.22.2
@@ -76,8 +76,8 @@ require (
 	golang.org/x/text v0.8.0 // indirect
 	golang.org/x/time v0.0.0-20210723032227-1f47c861a9ac // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 // indirect
-	google.golang.org/protobuf v1.28.1 // indirect
+	google.golang.org/genproto v0.0.0-20230320184635-7606e756e683 // indirect
+	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.66.2 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,6 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
 github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
 github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gocsi v1.7.0 h1:fMQO2zwAXCaIsUoPCcnnuPMwfQMoaI1/0aqkQVndlxU=

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gocsi v1.7.0 h1:fMQO2zwAXCaIsUoPCcnnuPMwfQMoaI1/0aqkQVndlxU=

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0 h1:8puwDAHQI+SI9KoKigJARxmwRE1tk40zRFekt6WQQ/o=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230316192210-d1b46db0cbe0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230330153121-7ee6c5ed22ea h1:mSoFePBjK5m66qR9h3Kgfk5YVJJrhO7cBTWDnVM6uAI=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230330153121-7ee6c5ed22ea/go.mod h1:Jfe99IlMhe0xasJ8hey0QdW2uDS6B0wrZ2pTBxs1S6M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gocsi v1.7.0 h1:fMQO2zwAXCaIsUoPCcnnuPMwfQMoaI1/0aqkQVndlxU=
@@ -195,8 +195,9 @@ github.com/golang/protobuf v1.4.1/go.mod h1:U8fpvMrcmy5pZrNK1lt4xCsGvpyWQ/VVv6QD
 github.com/golang/protobuf v1.4.2/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.4.3/go.mod h1:oDoupMAO8OvCJWAcko0GGGIgR6R6ocIYbsSw735rRwI=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
-github.com/golang/protobuf v1.5.2 h1:ROPKBNFfQgOUMifHyP+KYbvpjbdoFNs+aK7DXlji0Tw=
 github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
+github.com/golang/protobuf v1.5.3 h1:KhyjKVUg7Usr/dYsdSqoFveMYd5ko72D+zANwlG1mmg=
+github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.1/go.mod h1:xXMiIv4Fb/0kKde4SpL7qlzvu5cMJDRkFDxJfI9uaxA=
@@ -703,8 +704,8 @@ google.golang.org/genproto v0.0.0-20200513103714-09dca8ec2884/go.mod h1:55QSHmfG
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
 google.golang.org/genproto v0.0.0-20201019141844-1ed22bb0c154/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210602131652-f16073e35f0c/go.mod h1:UODoCrxHCcBojKKwX1terBiRUaqAsFqJiF615XL43r0=
-google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4 h1:DdoeryqhaXp1LtT/emMP1BRJPHHKFi5akj/nbx/zNTA=
-google.golang.org/genproto v0.0.0-20230306155012-7f2fa6fef1f4/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
+google.golang.org/genproto v0.0.0-20230320184635-7606e756e683 h1:khxVcsk/FhnzxMKOyD+TDGwjbEOpcPuIpmafPGFmhMA=
+google.golang.org/genproto v0.0.0-20230320184635-7606e756e683/go.mod h1:NWraEVixdDnqcqQ30jipen1STv2r/n24Wb7twVTGR4s=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.20.1/go.mod h1:10oTOabMzJvdu6/UiuZezV6QK5dSlG84ov/aaiqXj38=
 google.golang.org/grpc v1.21.1/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
@@ -716,8 +717,8 @@ google.golang.org/grpc v1.27.1/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8
 google.golang.org/grpc v1.29.0/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3IjizoKk=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc v1.38.0/go.mod h1:NREThFqKR1f3iQ6oBuvc5LadQuXVGo9rkm5ZGrQdJfM=
-google.golang.org/grpc v1.53.0 h1:LAv2ds7cmFV/XTS3XG1NneeENYrXGmorPxsBbptIjNc=
-google.golang.org/grpc v1.53.0/go.mod h1:OnIrk0ipVdj4N5d9IUoFUx72/VlD7+jUsHwZgwSMQpw=
+google.golang.org/grpc v1.54.0 h1:EhTqbhiYeixwWQtAEZAxmV9MGqcjEU2mFx52xCzNyag=
+google.golang.org/grpc v1.54.0/go.mod h1:PUSEXI6iWghWaB6lXM4knEgpJNu2qUcKfDtNci3EC2g=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
@@ -730,8 +731,8 @@ google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGj
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=
 google.golang.org/protobuf v1.26.0/go.mod h1:9q0QmTI4eRPtz6boOQmLYwt+qCgq0jsYwAQnmE0givc=
-google.golang.org/protobuf v1.28.1 h1:d0NfwRgPtno5B1Wa6L2DAG+KivqkdutMf1UhdNx175w=
-google.golang.org/protobuf v1.28.1/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
+google.golang.org/protobuf v1.30.0 h1:kPPoIgf3TsEvrm0PFe15JQ+570QVxYzEvvHqChK+cng=
+google.golang.org/protobuf v1.30.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjI
 github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gocsi v1.7.0 h1:fMQO2zwAXCaIsUoPCcnnuPMwfQMoaI1/0aqkQVndlxU=

--- a/go.sum
+++ b/go.sum
@@ -106,10 +106,6 @@ github.com/dell/dell-csi-extensions/common v1.1.1 h1:PXdqCm6lL1g02KuR9SrsrZeoTk6
 github.com/dell/dell-csi-extensions/common v1.1.1/go.mod h1:eHfx1rwttqdPZBy8cfvRbJYPElGa/NY4fRR/P//yndw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7hPY6nPkRAyFh0slw=
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
-github.com/dell/dell-csi-extensions/replication v1.3.0 h1:Z2w+jwoyBM4ESKhABLeRjIcWxJMd4Bnt3phEPeQhljw=
-github.com/dell/dell-csi-extensions/replication v1.3.0/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c h1:YRaaqDtQuSMrhRPIMVr+RJuaZwm6y0W1zecO7a7cyj8=
-github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230309190353-bdcdad213b0c/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057 h1:U3o1EyjtMHPnHsNLZkzzeHEgNVNfojzQZjOebVSfuNY=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230315203650-c10cd09b0057/go.mod h1:NhGyohTtW8sdZR9WHF7WK+/WaOY5wNnIjjSHweY0/7M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -19,7 +19,7 @@ import (
 	logrus "github.com/sirupsen/logrus"
 )
 
-//Log init
+// Log init
 var Log = logrus.New()
 
 // New returns a new Mock Storage Plug-in Provider.

--- a/service/csi_extension_server.go
+++ b/service/csi_extension_server.go
@@ -222,7 +222,7 @@ func (s *service) getSystemID(req *volumeGroupSnapshot.CreateVolumeGroupSnapshot
 
 }
 
-//validate if request has source volumes, a VGS name, and VGS name length < 27 chars
+// validate if request has source volumes, a VGS name, and VGS name length < 27 chars
 func validateCreateVGSreq(req *volumeGroupSnapshot.CreateVolumeGroupSnapshotRequest) error {
 	if len(req.SourceVolumeIDs) == 0 {
 		err := status.Errorf(codes.InvalidArgument, "SourceVolumeIDs cannot be empty")
@@ -284,10 +284,10 @@ func (s *service) buildSnapshotDefs(req *volumeGroupSnapshot.CreateVolumeGroupSn
 
 }
 
-//A VolumeGroupSnapshot request is idempotent if the following criteria is met:
-//1. For each snapshot we intend to make, there is a snapshot with the same name and ancestor ID on array
-//2. Each snapshot that we find to satisfy criteria 1 all belong to the same consistency group
-//3. The consistency group that satisfies criteria 2 contain no other snapshots
+// A VolumeGroupSnapshot request is idempotent if the following criteria is met:
+// 1. For each snapshot we intend to make, there is a snapshot with the same name and ancestor ID on array
+// 2. Each snapshot that we find to satisfy criteria 1 all belong to the same consistency group
+// 3. The consistency group that satisfies criteria 2 contain no other snapshots
 func (s *service) checkIdempotency(ctx context.Context, snapshotsToMake *siotypes.SnapshotVolumesParam, systemID string, snapGrpID string) (*volumeGroupSnapshot.CreateVolumeGroupSnapshotResponse, error) {
 	Log.Infof("CheckIdempotency called")
 
@@ -399,7 +399,7 @@ func (s *service) checkIdempotency(ctx context.Context, snapshotsToMake *siotype
 	return resp, nil
 }
 
-//build the response for CreateVGS to return
+// build the response for CreateVGS to return
 func (s *service) buildCreateVGSResponse(ctx context.Context, snapResponse *siotypes.SnapshotVolumesResp, snapshotDefs []*siotypes.SnapshotDef, systemID string) ([]*volumeGroupSnapshot.Snapshot, error) {
 	var groupSnapshots []*volumeGroupSnapshot.Snapshot
 	for index, id := range snapResponse.VolumeIDList {

--- a/service/ephemeral.go
+++ b/service/ephemeral.go
@@ -16,13 +16,14 @@ package service
 import (
 	"context"
 	"errors"
-	"github.com/container-storage-interface/spec/lib/go/csi"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
+
+	"github.com/container-storage-interface/spec/lib/go/csi"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 var (
@@ -55,7 +56,7 @@ func parseSize(size string) (int64, error) {
 	return 0, errors.New(message)
 }
 
-//Call complete stack: systemProbe, CreateVolume, ControllerPublishVolume, and NodePublishVolume
+// Call complete stack: systemProbe, CreateVolume, ControllerPublishVolume, and NodePublishVolume
 func (s *service) ephemeralNodePublish(
 	ctx context.Context,
 	req *csi.NodePublishVolumeRequest) (
@@ -206,8 +207,8 @@ func (s *service) ephemeralNodePublish(
 	return &csi.NodePublishVolumeResponse{}, nil
 }
 
-//Call stack: ControllerUnpublishVolume, DeleteVolume (NodeUnpublish will be already called by the time this method is called)
-//remove lockfile
+// Call stack: ControllerUnpublishVolume, DeleteVolume (NodeUnpublish will be already called by the time this method is called)
+// remove lockfile
 func (s *service) ephemeralNodeUnpublish(
 	ctx context.Context,
 	req *csi.NodeUnpublishVolumeRequest) error {

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -35,6 +35,18 @@ Scenario Outline: Test CreateRemoteVolume
   | "sourcevol" | "ProbePrimaryError"          | "PodmonControllerProbeError"        |
   | "sourcevol" | "ProbeSecondaryError"        | "PodmonControllerProbeError"        |
 
+@replication
+Scenario Outline: Test DeleteLocalVolume
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I induce error <error>
+  And I call DeleteLocalVolume
+  Then the error contains <errormsg>
+  Examples:
+  | name        | error                         | errormsg                            |
+  | "sourcevol" | "none"                        | "none"                              |
 
 @replication
 Scenario Outline: Test CreateStorageProtectionGroup

--- a/service/replication.go
+++ b/service/replication.go
@@ -215,7 +215,6 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 // DeleteLocalVolume deletes the backend volume on the storage array.
 func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 
-	Log.Printf("!!! Deleting Remote Volume !!!")
 	Log.Error("DeleteLocalVolume is not yet implemented")
 
 	return &replication.DeleteLocalVolumeResponse{}, nil

--- a/service/replication.go
+++ b/service/replication.go
@@ -212,8 +212,7 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 	}, nil
 }
 
-func (s *service) DeleteLocalVolume(ctx context.Context,
-	req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
+func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 
 	Log.Printf("!!! Deleting Remote Volume !!!")
 

--- a/service/replication.go
+++ b/service/replication.go
@@ -212,6 +212,14 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 	}, nil
 }
 
+func (s *service) DeleteRemoteVolume(ctx context.Context,
+	req *replication.DeleteRemoteVolumeRequest) (*replication.DeleteRemoteVolumeResponse, error) {
+
+	Log.Printf("!!! Deleting Remote Volume !!!")
+
+	return &replication.DeleteRemoteVolumeResponse{}, nil
+}
+
 func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {
 	Log.Printf("[CreateStorageProtectionGroup] - req %+v", req)
 

--- a/service/replication.go
+++ b/service/replication.go
@@ -216,8 +216,9 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 
 	Log.Printf("!!! Deleting Remote Volume !!!")
+	Log.Error("DeleteLocalVolume is not yet implemented")
 
-	return nil, fmt.Errorf("DeleteLocalVolume is not yet implemented")
+	return &replication.DeleteLocalVolumeResponse{}, nil
 }
 
 func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {

--- a/service/replication.go
+++ b/service/replication.go
@@ -217,7 +217,7 @@ func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.Delete
 
 	Log.Printf("!!! Deleting Remote Volume !!!")
 
-	return &replication.DeleteLocalVolumeResponse{}, fmt.Errorf("DeleteLocalVolume is not yet implemented")
+	return nil, fmt.Errorf("DeleteLocalVolume is not yet implemented")
 }
 
 func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {

--- a/service/replication.go
+++ b/service/replication.go
@@ -212,12 +212,12 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 	}, nil
 }
 
-func (s *service) DeleteRemoteVolume(ctx context.Context,
-	req *replication.DeleteRemoteVolumeRequest) (*replication.DeleteRemoteVolumeResponse, error) {
+func (s *service) DeleteLocalVolume(ctx context.Context,
+	req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 
 	Log.Printf("!!! Deleting Remote Volume !!!")
 
-	return &replication.DeleteRemoteVolumeResponse{}, nil
+	return &replication.DeleteLocalVolumeResponse{}, nil
 }
 
 func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {

--- a/service/replication.go
+++ b/service/replication.go
@@ -212,11 +212,12 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 	}, nil
 }
 
+// DeleteLocalVolume deletes the backend volume on the storage array.
 func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
 
 	Log.Printf("!!! Deleting Remote Volume !!!")
 
-	return &replication.DeleteLocalVolumeResponse{}, nil
+	return &replication.DeleteLocalVolumeResponse{}, fmt.Errorf("DeleteLocalVolume is not yet implemented")
 }
 
 func (s *service) CreateStorageProtectionGroup(ctx context.Context, req *replication.CreateStorageProtectionGroupRequest) (*replication.CreateStorageProtectionGroupResponse, error) {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3456,6 +3456,19 @@ func (f *feature) iCallCreateRemoteVolume() error {
 	return nil
 }
 
+func (f *feature) iCallDeleteLocalVolume() error {
+	ctx := new(context.Context)
+
+	req := &replication.DeleteLocalVolumeRequest{}
+
+	_, f.err = f.service.DeleteLocalVolume(*ctx, req)
+	if f.err != nil {
+		fmt.Printf("DeleteLocalVolume returned error: %s", f.err)
+	}
+
+	return nil
+}
+
 func (f *feature) iCallCreateStorageProtectionGroup() error {
 	ctx := new(context.Context)
 	parameters := make(map[string]string)
@@ -3794,6 +3807,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I set renameSDC with renameEnabled "([^"]*)" prefix "([^"]*)"$`, f.iSetRenameSdcEnabledWithPrefix)
 	s.Step(`^I set approveSDC with approveSDCEnabled "([^"]*)"`, f.iSetApproveSdcEnabled)
 	s.Step(`^I call CreateRemoteVolume$`, f.iCallCreateRemoteVolume)
+	s.Step(`^I call DeleteLocalVolume$`, f.iCallDeleteLocalVolume)
 	s.Step(`^I call CreateStorageProtectionGroup$`, f.iCallCreateStorageProtectionGroup)
 	s.Step(`^I call CreateStorageProtectionGroup with "([^"]*)", "([^"]*)", "([^"]*)"$`, f.iCallCreateStorageProtectionGroupWith)
 	s.Step(`^I call GetStorageProtectionGroupStatus$`, f.iCallGetStorageProtectionGroupStatus)

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -1371,8 +1371,8 @@ func (f *feature) iCallCreateVolumeGroupSnapshot() error {
 	return nil
 }
 
-//takes f.VolumeGroupSnapshot (assumes length >=2 ), and splits its snapshots into
-//two VolumeGroupSnapshots, f.volumeGroupSnapshot and  f.volumeGroupSnapshot2
+// takes f.VolumeGroupSnapshot (assumes length >=2 ), and splits its snapshots into
+// two VolumeGroupSnapshots, f.volumeGroupSnapshot and  f.volumeGroupSnapshot2
 func (f *feature) iCallSplitVolumeGroupSnapshot() error {
 	if f.VolumeGroupSnapshot == nil {
 		fmt.Printf("No VolumeGroupSnapshot to split.\n")
@@ -1594,7 +1594,7 @@ func (f *feature) theVolumeconditionIs(health string) error {
 	return nil
 }
 
-//add given suffix to name or use time as suffix and set to max of 30 characters
+// add given suffix to name or use time as suffix and set to max of 30 characters
 func makeAUniqueName(name *string) {
 	if name == nil {
 		temp := "tmp"


### PR DESCRIPTION
# Description
Stub added for DeleteLocalVolume, new gRPC call to allow for deletion of backend volume. Added for compatibility with csm-replication.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/665 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration
