### PR TITLE
Add Replication DeleteLocalVolume

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/dell/dell-csi-extensions/podmon v1.1.2 h1:U0p2IS3PA/GPXYwtmY3bM+xfhj7
 github.com/dell/dell-csi-extensions/podmon v1.1.2/go.mod h1:MozD04ji0JsA4yRdohPF/KzDiCE7S//5alfZqhleVco=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230330153121-7ee6c5ed22ea h1:mSoFePBjK5m66qR9h3Kgfk5YVJJrhO7cBTWDnVM6uAI=
 github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230330153121-7ee6c5ed22ea/go.mod h1:Jfe99IlMhe0xasJ8hey0QdW2uDS6B0wrZ2pTBxs1S6M=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230406184708-5d8c83b5fcae h1:gJHptyBhchWfFx4k2nxbqzkY4c3w4N4wqM6iZ9/7DJI=
+github.com/dell/dell-csi-extensions/replication v1.3.1-0.20230406184708-5d8c83b5fcae/go.mod h1:Jfe99IlMhe0xasJ8hey0QdW2uDS6B0wrZ2pTBxs1S6M=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2 h1:g3HZyuXgCiHpCkkVuCNKXFRETjvOkO6/16vrAH5ls90=
 github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.2/go.mod h1:6jxjVKuL6FPHcdPVQ4ABGJkOoTnZgHaMZXFb0PRBlPo=
 github.com/dell/gocsi v1.7.0 h1:fMQO2zwAXCaIsUoPCcnnuPMwfQMoaI1/0aqkQVndlxU=

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -37,16 +37,20 @@ Scenario Outline: Test CreateRemoteVolume
 
 @replication
 Scenario Outline: Test DeleteLocalVolume
-  Given a VxFlexOS service
+  Given a VxFlexOS service with timeout 120000 milliseconds
   And I use config "replication-config"
   When I call CreateVolume <name>
   And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I call DeleteVolume <name>
   And I induce error <error>
-  And I call DeleteLocalVolume
+  And I call DeleteLocalVolume <name>
   Then the error contains <errormsg>
   Examples:
   | name        | error                         | errormsg                            |
   | "sourcevol" | "none"                        | "none"                              |
+  | "sourcevol" | "BadVolumeHandleError"        | "volume handle is required"         |
+  | "sourcevol" | "RemoveVolumeError"           | "inducedError"                      |
 
 @replication
 Scenario Outline: Test CreateStorageProtectionGroup

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -37,7 +37,7 @@ Scenario Outline: Test CreateRemoteVolume
 
 @replication
 Scenario Outline: Test DeleteLocalVolume
-  Given a VxFlexOS service with timeout 120000 milliseconds
+  Given a VxFlexOS service
   And I use config "replication-config"
   When I call CreateVolume <name>
   And I call CreateRemoteVolume

--- a/service/features/replication.feature
+++ b/service/features/replication.feature
@@ -51,6 +51,23 @@ Scenario Outline: Test DeleteLocalVolume
   | "sourcevol" | "none"                        | "none"                              |
   | "sourcevol" | "BadVolumeHandleError"        | "volume handle is required"         |
   | "sourcevol" | "RemoveVolumeError"           | "inducedError"                      |
+  | "sourcevol" | "BadVolIDError"               | "failed to provide"                 |
+  | "sourcevol" | "TargetVolumeAlreadyDeleted"  | "none"                              |
+  | "sourcevol" | "GetVolByIDError"             | "can't query volume"                |
+
+@replication
+Scenario Outline: Test DeleteLocalVolume incorrect order
+  Given a VxFlexOS service
+  And I use config "replication-config"
+  When I call CreateVolume <name>
+  And I call CreateRemoteVolume
+  And I call CreateStorageProtectionGroup
+  And I call DeleteLocalVolume <name>
+  Then the error contains <errormsg>
+  Examples:
+  | name        | error                         | errormsg                            |
+  | "sourcevol" | "none"                        | "replication target volume marked"  |
+
 
 @replication
 Scenario Outline: Test CreateStorageProtectionGroup

--- a/service/features/volume.json.template
+++ b/service/features/volume.json.template
@@ -17,11 +17,11 @@
   "links": [
     {
       "rel": "self",
-      "href": "/api/instances/Volume::706f646d6f6e31"
+      "href": "/api/instances/Volume::__ID__"
     },
     {
       "rel": "/api/Volume/relationship/Statistics",
-      "href": "/api/instances/Volume::706f646d6f6e31/relationships/Statistics"
+      "href": "/api/instances/Volume::__ID__/relationships/Statistics"
     },
     {
       "rel": "/api/parent/relationship/vtreeId",

--- a/service/replication.go
+++ b/service/replication.go
@@ -193,7 +193,7 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 
 	createVolumeResponse, err := s.CreateVolume(ctx, volReq)
 	if err != nil {
-		log.Printf("CreateVolume called failed: %s", err.Error())
+		log.Printf("CreateVolume call failed: %s", err.Error())
 		return nil, err
 	}
 
@@ -224,7 +224,7 @@ func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.Delete
 
 	_, err := s.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volHandleCtx})
 	if err != nil {
-		log.Printf("DeleteLocalVolume called failed: %s", err.Error())
+		log.Printf("DeleteLocalVolume call failed: %s", err.Error())
 		return nil, err
 	}
 

--- a/service/replication.go
+++ b/service/replication.go
@@ -214,8 +214,19 @@ func (s *service) CreateRemoteVolume(ctx context.Context, req *replication.Creat
 
 // DeleteLocalVolume deletes the backend volume on the storage array.
 func (s *service) DeleteLocalVolume(ctx context.Context, req *replication.DeleteLocalVolumeRequest) (*replication.DeleteLocalVolumeResponse, error) {
+	Log.Printf("[DeleteLocalVolume] - req %+v", req)
 
-	Log.Error("DeleteLocalVolume is not yet implemented")
+	volHandleCtx := req.GetVolumeHandle()
+
+	if volHandleCtx == "" {
+		return nil, status.Error(codes.InvalidArgument, "volume handle is required")
+	}
+
+	_, err := s.DeleteVolume(ctx, &csi.DeleteVolumeRequest{VolumeId: volHandleCtx})
+	if err != nil {
+		log.Printf("DeleteLocalVolume called failed: %s", err.Error())
+		return nil, err
+	}
 
 	return &replication.DeleteLocalVolumeResponse{}, nil
 }

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3456,10 +3456,21 @@ func (f *feature) iCallCreateRemoteVolume() error {
 	return nil
 }
 
-func (f *feature) iCallDeleteLocalVolume() error {
+func (f *feature) iCallDeleteLocalVolume(name string) error {
 	ctx := new(context.Context)
 
-	req := &replication.DeleteLocalVolumeRequest{}
+	replicatedVolName := "replicated-" + name
+	volumeHandle := arrayID2 + "-" + volumeNameToID[replicatedVolName]
+
+	if inducedError.Error() == "BadVolumeHandleError" {
+		volumeHandle = ""
+	}
+
+	log.Printf("iCallDeleteLocalVolume name %s to ID %s", name, volumeHandle)
+
+	req := &replication.DeleteLocalVolumeRequest{
+		VolumeHandle: volumeHandle,
+	}
 
 	_, f.err = f.service.DeleteLocalVolume(*ctx, req)
 	if f.err != nil {
@@ -3807,7 +3818,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I set renameSDC with renameEnabled "([^"]*)" prefix "([^"]*)"$`, f.iSetRenameSdcEnabledWithPrefix)
 	s.Step(`^I set approveSDC with approveSDCEnabled "([^"]*)"`, f.iSetApproveSdcEnabled)
 	s.Step(`^I call CreateRemoteVolume$`, f.iCallCreateRemoteVolume)
-	s.Step(`^I call DeleteLocalVolume$`, f.iCallDeleteLocalVolume)
+	s.Step(`^I call DeleteLocalVolume "([^"]*)"$`, f.iCallDeleteLocalVolume)
 	s.Step(`^I call CreateStorageProtectionGroup$`, f.iCallCreateStorageProtectionGroup)
 	s.Step(`^I call CreateStorageProtectionGroup with "([^"]*)", "([^"]*)", "([^"]*)"$`, f.iCallCreateStorageProtectionGroupWith)
 	s.Step(`^I call GetStorageProtectionGroupStatus$`, f.iCallGetStorageProtectionGroupStatus)

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -150,7 +150,7 @@ func (f *feature) checkGoRoutines(tag string) {
 }
 
 func (f *feature) aVxFlexOSService() error {
-	return f.aVxFlexOSServiceWithTimeoutMilliseconds(50)
+	return f.aVxFlexOSServiceWithTimeoutMilliseconds(150)
 }
 
 func (f *feature) aVxFlexOSServiceWithTimeoutMilliseconds(millis int) error {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3465,6 +3465,9 @@ func (f *feature) iCallDeleteLocalVolume(name string) error {
 	if inducedError.Error() == "BadVolumeHandleError" {
 		volumeHandle = ""
 	}
+	if stepHandlersErrors.BadVolIDError {
+		volumeHandle = "/"
+	}
 
 	log.Printf("iCallDeleteLocalVolume name %s to ID %s", name, volumeHandle)
 

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -725,6 +725,12 @@ func handleAction(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		pairs := systemArrays[r.Host].replicationPairs
+
+		// Set replication state
+		targetSystem := systemArrays[r.Host].replicationSystem
+		remoteVolume := pairs[id]["remoteVolumeId"]
+		targetSystem.volumes[remoteVolume]["volumeReplicationState"] = unmarkedForReplication
+
 		delete(pairs, id)
 
 		fmt.Printf("volumeIDToReplicationState %+v\n", volumeIDToReplicationState)

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -937,8 +937,8 @@ func handleInstances(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if stepHandlersErrors.SIOGatewayVolumeNotFoundError {
-		writeError(w, "Could not find the volume", http.StatusRequestTimeout, codes.Internal)
+	if stepHandlersErrors.SIOGatewayVolumeNotFoundError || inducedError.Error() == "TargetVolumeAlreadyDeleted" {
+		writeError(w, sioGatewayVolumeNotFound, http.StatusRequestTimeout, codes.Internal)
 		return
 	}
 


### PR DESCRIPTION
# Description
Adds the implementation of deleting the local volume from the target driver. Previously, when the source volume was deleted, the target volume on the cluster and array would remain. This would result in not abiding by the `remoteRetentionPolicy` defined in the storage class.

The new GRPC call ensures that the Replication controller will execute this on the target driver so that we follow the appropriate `remoteRetentionPolicy`.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/754 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Tested with a storage class that contains a `remoteRetentionPolicy` of `Delete`. The k8s PVs and PowerFlex arrays volumes were deleted.
- [x] Tested with a storage class that contains a `remoteRetentionPolicy` of `Retains`. The k8s PVs and PowerFlex arrays volumes were NOT deleted (expected).