### PR TITLE
fix the k8s registry for health-monitor-controller.

### DIFF
--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "gcr.io/k8s-staging-sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
https://github.com/dell/csi-powerflex/pull/180/files#diff-9b4701bf6ee1af5c8bdc6eae5052ed420510463c7efb8c6c1e5b48612e44a642R47
The above pr missed to update the k8s registry of healthmonitor controller.
This pr address the above issue.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/744 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the csi-powerflex driver with the changes and driver got installed successfully. 
- [x] Ran cert-csi and it passed with 100%


```
 Normal  Pulling    23s   kubelet            Pulling image "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0"
  Normal  Pulled     21s   kubelet            Successfully pulled image "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" in 1.89471679s (2.127385319s including waiting)
  Normal  Created    21s   kubelet            Created container csi-external-health-monitor-controller
  Normal  Started    20s   kubelet            Started container csi-external-health-monitor-controller
```


```
master-1-LHFa5fuAy6gvi:~/csi-powerflex/dell-csi-helm-installer # kubectl get pods -n vxflexos
NAME                                   READY   STATUS    RESTARTS   AGE
vxflexos-controller-7958b8988c-pncl8   6/6     Running   0          11s
vxflexos-controller-7958b8988c-psl4l   6/6     Running   0          11s
vxflexos-node-8fqww                    2/2     Running   0          11s
vxflexos-node-sk6bf                    2/2     Running   0          11s
```

```
[2023-05-19 07:14:07]  INFO Avg time of a run:   63.03s
[2023-05-19 07:14:07]  INFO Avg time of a del:   13.33s
[2023-05-19 07:14:07]  INFO Avg time of all:     80.78s
[2023-05-19 07:14:07]  INFO During this run 100.0% of suites succeeded
```
