### PR TITLE
bug fix for parsing uncommented lines only

### DIFF
--- a/dell-csi-helm-installer/install-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/install-csi-vxflexos.sh
@@ -22,7 +22,7 @@ function install_mdm_secret() {
     log error "secret ${SECRET} in namespace ${NS} not found"
   else
     JSON=$(kubectl get secret ${SECRET} -n ${NS} -o go-template='{{ .data.config }}' | base64 --decode)
-    DATA=$(echo "${JSON}" | grep -v '#' | grep mdm | awk -F "\"" '{ print $(NF-1)}')
+    DATA=$(echo "${JSON}" | grep -v '^#' | grep mdm | awk -F "\"" '{ print $(NF-1)}')
     MDM=$(echo ${DATA} | sed "s/ /\&/g")
     if [ "${MDM}" != "" ]; then
       ENC=$(echo ${MDM} | base64 | tr -d "\n")

--- a/dell-csi-helm-installer/install-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/install-csi-vxflexos.sh
@@ -22,7 +22,7 @@ function install_mdm_secret() {
     log error "secret ${SECRET} in namespace ${NS} not found"
   else
     JSON=$(kubectl get secret ${SECRET} -n ${NS} -o go-template='{{ .data.config }}' | base64 --decode)
-    DATA=$(echo "${JSON}" | grep mdm | awk -F "\"" '{ print $(NF-1)}')
+    DATA=$(echo "${JSON}" | grep -v '#' | grep mdm | awk -F "\"" '{ print $(NF-1)}')
     MDM=$(echo ${DATA} | sed "s/ /\&/g")
     if [ "${MDM}" != "" ]; then
       ENC=$(echo ${MDM} | base64 | tr -d "\n")

--- a/dell-csi-helm-installer/install-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/install-csi-vxflexos.sh
@@ -22,7 +22,7 @@ function install_mdm_secret() {
     log error "secret ${SECRET} in namespace ${NS} not found"
   else
     JSON=$(kubectl get secret ${SECRET} -n ${NS} -o go-template='{{ .data.config }}' | base64 --decode)
-    DATA=$(echo "${JSON}" | grep -v '^#' | grep mdm | awk -F "\"" '{ print $(NF-1)}')
+    DATA=$(echo "${JSON}" | grep -v '^#*' | grep mdm | awk -F "\"" '{ print $(NF-1)}')
     MDM=$(echo ${DATA} | sed "s/ /\&/g")
     if [ "${MDM}" != "" ]; then
       ENC=$(echo ${MDM} | base64 | tr -d "\n")


### PR DESCRIPTION
# Description
This PR includes changes to parse only uncommented lines when constructing MDM key from secret file.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/835 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] The secret key is formed and driver is installed after the changes are made in installation script.

**sceret.yaml:**
```
#- username: "<username>"
#  password: "<password>"
#  systemID: "<systemID>"
#  endpoint: "<endpoint url>"
#  skipCertificateValidation: true
#  mdm: "<IP1>, <IP2>"
- username: "<username1>"
  password: "<password1>"
  systemID: "<systemID1>"
  endpoint: "<endpoint url>"
  skipCertificateValidation: true
  mdm: "<IP2>, <IP3>"
```
**Driver installation vis helm:**
```
./csi-install.sh --namespace vxflexos --values ../helm/csi-vxflexos/values.yaml --skip-verify
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
WARNING: This version information is deprecated and will be replaced with the output from kubectl version --short.  Use --output=yaml|json to get the full version.
------------------------------------------------------
> Installing CSI Driver: csi-vxflexos on 1.27
------------------------------------------------------
------------------------------------------------------
> Checking to see if CSI Driver is already installed
------------------------------------------------------
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/.kube/config
Skipping verification at user request
|
|- Installing Driver                                                |
|- Get SDC config and make MDM string for multi array support       |
|- SDC MDM value created : <IP1>, <IP2>              |
|- IP ADDR <IP1> format is ok                               |
|- IP ADDR <IP2> format is ok                               Success
  |
  |--> Waiting for Deployment vxflexos-controller to be ready       Success
  |
  |--> Waiting for DaemonSet vxflexos-node to be ready              Success
------------------------------------------------------
> Operation complete
------------------------------------------------------

k get secret vxflexos-config -n vxflexos -o yaml
apiVersion: v1
data:
  MDM: MTAuMjQ3LjEwMS42MCwxMC4yNDcuMTAxLjY4Cg==
  config: IyAzLjYgYXJyYXkKLSB1c2VybmFtZTogImFkbWluIgogIHBhc3N3b3JkOiAiUGFzc3dvcmQxMjMiCiAgc3lzdGVtSUQ6ICIwZTdhMDgyODYyZmVkZjBmIgogIGVuZHBvaW50OiAiaHR0cHM6Ly8xMC4yNDcuMTAxLjY5IgogIHNraXBDZXJ0aWZpY2F0ZVZhbGlkYXRpb246IHRydWUKICBtZG06ICIxMC4yNDcuMTAxLjYwLDEwLjI0Ny4xMDEuNjgiCiMtIHVzZXJuYW1lOiAiYWRtaW4iCiMgIHBhc3N3b3JkOiAiUGFzc3dvcmQxMjMiCiMgIHN5c3RlbUlEOiAiMmIxMWJiMTExMTExYmIxYiIKIyAgZW5kcG9pbnQ6ICJodHRwczovLzEyNy4wLjAuMiIKIyAgc2tpcENlcnRpZmljYXRlVmFsaWRhdGlvbjogdHJ1ZQojICBtZG06ICIxMC4wLjAuMywxMC4wLjAuNCIKIyAgbWRtOiAiMTAuMC4wLjMsMTAuMC4wLjQiCiMgIG1kbTogIjEwLjAuMC4zLDEwLjAuMC40IgojICBtZG06ICIxMC4wLjAuMywxMC4wLjAuNCIKIyAgbWRtOiAiMTAuMC4wLjMsMTAuMC4wLjQiCiMgIG1kbTogIjEwLjAuMC4zLDEwLjAuMC40Igo=
kind: Secret
metadata:
  creationTimestamp: "2023-05-26T03:47:57Z"
  name: vxflexos-config
  namespace: vxflexos
  resourceVersion: "6488678"
  uid: 684bd93c-3f0e-4a58-ac6f-d11a0d237b4b
type: Opaque

echo MTAuMjQ3LjEwMS42MCwxMC4yNDcuMTAxLjY4Cg== | base64 -d
<IP1>,<IP2>
```
- [x] tested for secret.yaml against the below syntax:
```
- mdm: "<IP2>, <IP3>" # supply mdm Ips here
- mdm: "<IP2>, <IP3>" #supply mdm Ips here
- mdm: "<IP2>, <IP3>" # mdm Ips here
- mdm: "<IP2>, <IP3>" #mdm Ips here
- #mdm: "<IP2>, <IP3>"
```