### PR TITLE
K8 1.27 sidecar versions updated

### DIFF
--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -4,7 +4,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.2.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -12,7 +12,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.4.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -20,7 +20,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.1" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -28,7 +28,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.7.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -36,7 +36,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.6.3" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}
@@ -44,7 +44,7 @@ Return the appropriate sidecar images based on k8s version
 {{- define "csi-vxflexos.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
     {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
-      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.8.0" -}}
+      {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}


### PR DESCRIPTION
# Description
This Pr includes the changes for updating the K8 1.27 sidecar versions used by the driver

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/743 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed driver with sidecars, described the pods to check and verify the versions
```
  attacher:
    Container ID:  containerd://d43d2b0307f78fa062569ec520830351ae51df78f17be15230b9bcfee4387f98
    Image:         registry.k8s.io/sig-storage/csi-attacher:v4.3.0
    Image ID:      registry.k8s.io/sig-storage/csi-attacher@sha256:4eb73137b66381b7b5dfd4d21d460f4b4095347ab6ed4626e0199c29d8d021af
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=$(ADDRESS)
      --v=5
      --leader-election=true
    State:          Running
      Started:      Fri, 02 Jun 2023 01:52:58 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /var/run/csi/csi.sock
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
  provisioner:
    Container ID:  containerd://ff97a9830d73921af5c6693ce678baf178f54c8c074e8c876dacb08bf02f4f27
    Image:         registry.k8s.io/sig-storage/csi-provisioner:v3.5.0
    Image ID:      registry.k8s.io/sig-storage/csi-provisioner@sha256:d078dc174323407e8cc6f0f9abd4efaac5db27838f1564d0253d5e3233e3f17f
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=$(ADDRESS)
      --feature-gates=Topology=true
      --volume-name-prefix=k8s
      --volume-name-uuid-length=10
      --leader-election=true
      --timeout=120s
      --v=5
      --default-fstype=ext4
      --extra-create-metadata
    State:          Running
      Started:      Fri, 02 Jun 2023 01:53:05 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /var/run/csi/csi.sock
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
  csi-external-health-monitor-controller:
    Container ID:  containerd://f9baae6d6223e9d040ed66732f0577aae2abec3233b700a22a68915e1a4ebb6a
    Image:         registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0
    Image ID:      registry.k8s.io/sig-storage/csi-external-health-monitor-controller@sha256:ee4458b1b0b9612de81f2607b4214c6838fa333b133c845da0995fc40fb1936e
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=$(ADDRESS)
      --v=5
      --leader-election=true
      --enable-node-watcher=true
      --http-endpoint=:8080
      --monitor-interval=60s
      --timeout=180s
    State:          Running
      Started:      Fri, 02 Jun 2023 01:53:09 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /var/run/csi/csi.sock
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
  snapshotter:
    Container ID:  containerd://b85f089b6c6c11ecf718f1cd49de3e6366869dcde8db78d1415006c643d25131
    Image:         registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2
    Image ID:      registry.k8s.io/sig-storage/csi-snapshotter@sha256:becc53e25b96573f61f7469923a92fb3e9d3a3781732159954ce0d9da07233a2
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=$(ADDRESS)
      --timeout=120s
      --v=5
      --leader-election=true
    State:          Running
      Started:      Fri, 02 Jun 2023 01:53:12 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /var/run/csi/csi.sock
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
  resizer:
    Container ID:  containerd://bd62d4cb3b58337d2907969f7ac7c2ba7fe986784e24f39a2429316eb96d5027
    Image:         registry.k8s.io/sig-storage/csi-resizer:v1.8.0
    Image ID:      registry.k8s.io/sig-storage/csi-resizer@sha256:2e2b44393539d744a55b9370b346e8ebd95a77573064f3f9a8caf18c22f4d0d0
    Port:          <none>
    Host Port:     <none>
    Args:
      --csi-address=$(ADDRESS)
      --v=5
      --leader-election=true
    State:          Running
      Started:      Fri, 02 Jun 2023 01:53:14 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      ADDRESS:  /var/run/csi/csi.sock
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
  driver:
    Container ID:  containerd://82750a6ffa1fb690b3f9302f194ddf9c5397301af888113512aaf7a19ea23289
    Image:         amaas-eos-mw1.cec.lab.emc.com:5036/csi-vxflexos:vmain-latest
    Image ID:      amaas-eos-mw1.cec.lab.emc.com:5036/csi-vxflexos@sha256:5813426c6be29bd9bf714fa112e806ccfe6d8b38b925bc71f63bdc061ccb14d2
    Port:          <none>
    Host Port:     <none>
    Command:
      /csi-vxflexos.sh
    Args:
      --leader-election
      --array-config=/vxflexos-config/config
      --driver-config-params=/vxflexos-config-params/driver-config-params.yaml
    State:          Running
      Started:      Fri, 02 Jun 2023 01:53:14 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      CSI_ENDPOINT:                             /var/run/csi/csi.sock
      X_CSI_MODE:                               controller
      X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE:    false
      X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT:  false
      SSL_CERT_DIR:                             /certs
      X_CSI_HEALTH_MONITOR_ENABLED:             true
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-5xmgs (ro)
      /vxflexos-config from vxflexos-config (rw)
      /vxflexos-config-params from vxflexos-config-params (rw)
```
- [x] Ran cert csi test suites
```
./cert-csi certify --cert-config /root/rajshree/certify.yaml --vsc vxflexos-snapclass
[2023-06-02 03:08:43]  INFO Starting cert-csi; ver. 0.8.1
[2023-06-02 03:08:43]  INFO Suites to run with vxflexos storage class:
[2023-06-02 03:08:43]  INFO 1. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
[2023-06-02 03:08:43]  INFO 2. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
[2023-06-02 03:08:43]  INFO 3. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
[2023-06-02 03:08:43]  INFO 4. SnapSuite {snapshots: 3, volumeSize; 8Gi}
[2023-06-02 03:08:43]  INFO 5. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
Does it look OK? (Y)es/(n)o
-> yes
[2023-06-02 03:08:45]  INFO Using EVENT observer type
[2023-06-02 03:08:45]  INFO Using default config
[2023-06-02 03:08:45]  INFO Successfully loaded config. Host: https://10.247.96.93:6443
[2023-06-02 03:08:45]  INFO Created new KubeClient
[2023-06-02 03:08:45]  INFO Running 1 iteration(s)
[2023-06-02 03:08:45]  INFO     *** ITERATION NUMBER 1 ***
.
.
.
.
.
.
[2023-06-02 03:11:34]  INFO Avg time of a run:   67.47s
[2023-06-02 03:11:34]  INFO Avg time of a del:   27.01s
[2023-06-02 03:11:34]  INFO Avg time of all:     99.89s
[2023-06-02 03:11:34]  INFO During this run 100.0% of suites succeeded
```

