### PR TITLE
fix offline installer bug.

### DIFF
--- a/dell-csi-helm-installer/csi-offline-bundle.sh
+++ b/dell-csi-helm-installer/csi-offline-bundle.sh
@@ -91,8 +91,8 @@ build_image_manifest() {
 
   # Forming this only for drivers supporting standalone helm charts
   if [ ! -z ${DRIVERREPO} ]; then 
-   echo "${DRIVERREPO}/${DRIVERNAME}\:v${DRIVERVERSIONVALUESYAML}"
-   echo "${DRIVERREPO}/${DRIVERNAME}:v${DRIVERVERSIONVALUESYAML}" >> "${IMAGEMANIFEST}.tmp"
+   echo "${DRIVERREPO}/${DRIVERNAME}\:${DRIVERVERSIONVALUESYAML}"
+   echo "${DRIVERREPO}/${DRIVERNAME}:${DRIVERVERSIONVALUESYAML}" >> "${IMAGEMANIFEST}.tmp"
   fi
   # sort and uniqify the list
   cat "${IMAGEMANIFEST}.tmp" | sort | uniq > "${IMAGEMANIFEST}"


### PR DESCRIPTION
# Description
This pr addresses the bug in the offline bundle installation using csi-powerflex.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/868 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the csi-powerflex driver using offline installer on both k8s and ocp the installation is successful 
- [x] Ran cert-csi and it passed with 100%
