### PR TITLE
release 2.7.1 changes.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ LABEL vendor="Dell Inc." \
     name="csi-powerflex" \
     summary="CSI Driver for Dell EMC PowerFlex" \
     description="CSI Driver for provisioning persistent storage from Dell EMC PowerFlex" \
-    version="2.7.0" \
+    version="2.7.1" \
     license="Apache-2.0"
 COPY ./licenses /licenses
 

--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -19,7 +19,7 @@ PROG="${0}"
 NODE_VERIFY=1
 VERIFY=1
 MODE="install"
-DEFAULT_DRIVER_VERSION="v2.7.0"
+DEFAULT_DRIVER_VERSION="v2.7.1"
 WATCHLIST=""
 
 # export the name of the debug log, so child processes will see it

--- a/helm/csi-vxflexos/Chart.yaml
+++ b/helm/csi-vxflexos/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: "2.7.0"
+appVersion: "2.7.1"
 kubeVersion: ">= 1.21.0 < 1.28.0"
 # If you are using a complex K8s version like "v1.21.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
@@ -16,4 +16,4 @@ maintainers:
 name: csi-vxflexos
 sources:
 - https://github.com/dell/csi-vxflexos
-version: "2.7.0"
+version: "2.7.1"

--- a/helm/csi-vxflexos/values.yaml
+++ b/helm/csi-vxflexos/values.yaml
@@ -3,7 +3,7 @@
 
 # "version" is used to verify the values file matches driver version
 # Not recommend to change
-version: v2.7.0
+version: v2.7.1
 
 images:
   # "driver" defines the container image, used for the driver container.


### PR DESCRIPTION
# Description
This pr addresses the csi-powerflex release v2.7.1 changes.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/911 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Cert-csi results
```
[2023-07-28 02:46:48]  INFO Avg time of a run:   61.56s
[2023-07-28 02:46:48]  INFO Avg time of a del:   27.82s
[2023-07-28 02:46:48]  INFO Avg time of all:     92.59s
[2023-07-28 02:46:48]  INFO During this run 100.0% of suites succeeded
```

- [x] Getplugin Info
`time="2023-07-28T06:38:32Z" level=info msg="/csi.v1.Identity/GetPluginInfo: REP 0005: Name=csi-vxflexos.dellemc.com, VendorVersion=2.7.0+1+dirty, Manifest=map[commit:44bc08e3f9018c7dfd51b4c5a1215de091430b74 formed:Fri, 28 Jul 2023 05:58:48 UTC semver:2.7.0+1+dirty url:http://github.com/dell/csi-vxflexos], XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
`