### PR TITLE
Storage Capacity Tracking Changes for csi-powerflex

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.3-0.20230517135918-9920e636bff1
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
-	github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1
+	github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.3-0.20230517135918-9920e636bff1
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
-	github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18
+	github.com/dell/goscaleio v1.11.1-0.20230814091931-a6e40e8fc1f3
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/dell/goscaleio v1.11.1-0.20230801144441-83fb98205f02 h1:o4M+prXXj2k0f
 github.com/dell/goscaleio v1.11.1-0.20230801144441-83fb98205f02/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1 h1:Mqxwnv6+BVkIKqwAny+MY1d9JloA1AsazIFmKxfU6yU=
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
+github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18 h1:bLXdfDVdJ/EuGVX6ro+7OljDKaS8Pvlx2Mg6HLf2mpw=
+github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1 h1:Mqxwnv6+BVkIK
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18 h1:bLXdfDVdJ/EuGVX6ro+7OljDKaS8Pvlx2Mg6HLf2mpw=
 github.com/dell/goscaleio v1.11.1-0.20230807101834-cdbd92a51a18/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
+github.com/dell/goscaleio v1.11.1-0.20230814091931-a6e40e8fc1f3 h1:tF3Hdmt3QQqS1rJDbXFFdbiUtnDWuMpbtaWbEHCLHvU=
+github.com/dell/goscaleio v1.11.1-0.20230814091931-a6e40e8fc1f3/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/service/features/get_storage_pool_statistics.json
+++ b/service/features/get_storage_pool_statistics.json
@@ -62,6 +62,7 @@
   "rfcacheIosOutstanding": 0,
   "protectedVacInKb": 50331648,
   "capacityAvailableForVolumeAllocationInKb": 117440512,
+  "volumeAllocationLimitInKb": 117440512,
   "numOfMappedToAllVolumes": 0,
   "activeMovingRebalanceJobs": 0,
   "activeMovingInFwdRebuildJobs": 0,

--- a/service/service.go
+++ b/service/service.go
@@ -465,6 +465,7 @@ func (s *service) BeforeServe(
 	}
 
 	opts.Thick = pb(EnvThick)
+	opts.Thick = true
 	opts.AutoProbe = true
 
 	s.opts = opts

--- a/service/service.go
+++ b/service/service.go
@@ -465,7 +465,6 @@ func (s *service) BeforeServe(
 	}
 
 	opts.Thick = pb(EnvThick)
-	opts.Thick = true
 	opts.AutoProbe = true
 
 	s.opts = opts


### PR DESCRIPTION
# Description
This pr adds the changes in the GetCapacity Rpc call to support the Storage Capacity tracking for csi-powerflex

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] I have tested the following scenarios
      1. Installed the csi-powerflex driver enabling the storage capacity in the values.yaml. 
               observations:
                    the driver installation is successful
                    the storage capacity objects are created with the available capacity
       2.  Run volume helm test for both thick and thin provisioning
            I am able to verify the GetCapacity call is showing correct available capacity 
        
             
