### PR TITLE
remove deprecated io/ioutil from csi-powerflex

### DIFF
--- a/core/semver/semver.go
+++ b/core/semver/semver.go
@@ -19,7 +19,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -71,7 +70,7 @@ func main() {
 	} else {
 		/* #nosec G304 */
 		if fileExists(format) {
-			buf, err := ioutil.ReadFile(format)
+			buf, err := os.ReadFile(format)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "error: read tpl failed: %v\n", err)
 				os.Exit(1)

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.3-0.20230517135918-9920e636bff1
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
-	github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1
+	github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.3-0.20230517135918-9920e636bff1
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
-	github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f
+	github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.3-0.20230517135918-9920e636bff1
 	github.com/dell/gocsi v1.7.0
 	github.com/dell/gofsutil v1.12.0
-	github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357
+	github.com/dell/goscaleio v1.11.1-0.20230816075825-380ffbcbcd75
 	github.com/fsnotify/fsnotify v1.5.1
 	github.com/golang/protobuf v1.5.3
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -124,6 +124,8 @@ github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1 h1:Mqxwnv6+BVkIK
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f h1:mulJskh+lec1FV1BRFXsovpVkhFWhIyR46KGAH2uUqo=
 github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
+github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357 h1:JqOuIbByrHbFzGFS2O+MFiGx4fJX+KTd9hhE974N2ic=
+github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/go.sum
+++ b/go.sum
@@ -122,6 +122,8 @@ github.com/dell/goscaleio v1.11.1-0.20230801144441-83fb98205f02 h1:o4M+prXXj2k0f
 github.com/dell/goscaleio v1.11.1-0.20230801144441-83fb98205f02/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1 h1:Mqxwnv6+BVkIKqwAny+MY1d9JloA1AsazIFmKxfU6yU=
 github.com/dell/goscaleio v1.11.1-0.20230804051431-657fcb1e35a1/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
+github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f h1:mulJskh+lec1FV1BRFXsovpVkhFWhIyR46KGAH2uUqo=
+github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/go.sum
+++ b/go.sum
@@ -126,6 +126,8 @@ github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f h1:mulJskh+lec1F
 github.com/dell/goscaleio v1.11.1-0.20230814062438-99b71c83cc3f/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357 h1:JqOuIbByrHbFzGFS2O+MFiGx4fJX+KTd9hhE974N2ic=
 github.com/dell/goscaleio v1.11.1-0.20230814093052-31a7de951357/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
+github.com/dell/goscaleio v1.11.1-0.20230816075825-380ffbcbcd75 h1:2bCpRCPqfzueF+ASLyjc1ZH7SN7GH8+rB6jbBcxeCck=
+github.com/dell/goscaleio v1.11.1-0.20230816075825-380ffbcbcd75/go.mod h1:dMTrHnXSsPus+Kd9mrs0JuyrCndoKvFP/bbEdc21Bi8=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=

--- a/service/ephemeral.go
+++ b/service/ephemeral.go
@@ -16,7 +16,6 @@ package service
 import (
 	"context"
 	"errors"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -224,7 +223,7 @@ func (s *service) ephemeralNodeUnpublish(
 
 	//while a file is being read from, it's a file determined by volID and is written by the driver
 	/* #nosec G304 */
-	dat, err := ioutil.ReadFile(lockFile)
+	dat, err := os.ReadFile(lockFile)
 	if err != nil && os.IsNotExist(err) {
 		return status.Error(codes.Internal, "Inline ephemeral. Was unable to read lockfile")
 	}

--- a/service/node.go
+++ b/service/node.go
@@ -23,8 +23,6 @@ import (
 	"strings"
 	"time"
 
-	"io/ioutil"
-
 	csi "github.com/container-storage-interface/spec/lib/go/csi"
 	"github.com/dell/gofsutil"
 	"github.com/dell/goscaleio"
@@ -267,7 +265,7 @@ func (s *service) NodeUnpublishVolume(
 		ephemeralVolume = true
 		//while a file is being read from, it's a file determined by volID and is written by the driver
 		/* #nosec G304 */
-		idFromFile, err := ioutil.ReadFile(lockFile)
+		idFromFile, err := os.ReadFile(lockFile)
 		if err != nil && os.IsNotExist(err) {
 			Log.Errorf("NodeUnpublish with ephemeral volume. Was unable to read lockfile: %v", err)
 			return nil, status.Error(codes.Internal, "NodeUnpublish with ephemeral volume. Was unable to read lockfile")

--- a/service/service.go
+++ b/service/service.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"path/filepath"
@@ -801,7 +800,7 @@ func getArrayConfig(ctx context.Context) (map[string]*ArrayConnectionData, error
 		return nil, fmt.Errorf(fmt.Sprintf("File %s does not exist", ArrayConfigFile))
 	}
 
-	config, err := ioutil.ReadFile(filepath.Clean(ArrayConfigFile))
+	config, err := os.ReadFile(filepath.Clean(ArrayConfigFile))
 	if err != nil {
 		return nil, fmt.Errorf(fmt.Sprintf("File %s errors: %v", ArrayConfigFile, err))
 	}

--- a/service/step_handlers_test.go
+++ b/service/step_handlers_test.go
@@ -17,9 +17,9 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -993,7 +993,7 @@ func handlePeerMdmInstances(w http.ResponseWriter, r *http.Request) {
 }
 
 func returnJSONFile(directory, filename string, w http.ResponseWriter, replacements map[string]string) (jsonBytes []byte) {
-	jsonBytes, err := ioutil.ReadFile(filepath.Join(directory, filename))
+	jsonBytes, err := os.ReadFile(filepath.Join(directory, filename))
 	if err != nil {
 		log.Printf("Couldn't read %s/%s\n", directory, filename)
 		if w != nil {

--- a/test/e2e-fsgroup/fs.go
+++ b/test/e2e-fsgroup/fs.go
@@ -16,11 +16,12 @@ package e2e
 import (
 	"context"
 	"fmt"
-	yaml "gopkg.in/yaml.v3"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 	"time"
+
+	yaml "gopkg.in/yaml.v3"
 
 	"github.com/onsi/ginkgo"
 	"github.com/onsi/gomega"
@@ -322,7 +323,7 @@ func doOneCyclePVCTest(ctx context.Context, policy string, accessMode v1.Persist
 
 func readYaml(values string) (map[string]string, error) {
 
-	yfile, err := ioutil.ReadFile(values)
+	yfile, err := os.ReadFile(values)
 
 	if err != nil {
 		return nil, err

--- a/test/integration/integration_test.go
+++ b/test/integration/integration_test.go
@@ -17,7 +17,6 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net"
 	"os"
 	"strings"
@@ -45,7 +44,7 @@ var grpcClient *grpc.ClientConn
 func init() {
 	/* load array config and give proper errors if not ok*/
 	if _, err := os.Stat(configFile); err == nil {
-		if _, err := ioutil.ReadFile(configFile); err != nil {
+		if _, err := os.ReadFile(configFile); err != nil {
 			err = fmt.Errorf("DEBUG integration pre requisites missing %s with multi array configuration file ", configFile)
 			panic(err)
 		}

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -19,7 +19,7 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"math"
 	"net/http"
@@ -138,7 +138,7 @@ func (f *feature) getArrayConfig() (map[string]*ArrayConnectionData, error) {
 		return nil, fmt.Errorf(fmt.Sprintf("File %s does not exist", configFile))
 	}
 
-	config, err := ioutil.ReadFile(filepath.Clean(configFile))
+	config, err := os.ReadFile(filepath.Clean(configFile))
 	if err != nil {
 		return nil, fmt.Errorf(fmt.Sprintf("File %s errors: %v", configFile, err))
 	}
@@ -1474,7 +1474,7 @@ func (f *feature) iReadWriteToVolume(folder string) error {
 	path := fmt.Sprintf("%s/%s", folder, "file")
 	fp, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0755)
 	if err != nil {
-		files, err1 := ioutil.ReadDir(path)
+		files, err1 := os.ReadDir(path)
 		if err1 != nil {
 			fmt.Printf("Write block read dir  %s", err1.Error())
 		}
@@ -1929,12 +1929,12 @@ func (f *feature) restCallToSetName(auth string, url string, name string) (strin
 		return "", err
 	}
 	if name == "" {
-		responseData, _ := ioutil.ReadAll(resp.Body)
+		responseData, _ := io.ReadAll(resp.Body)
 		token := regexp.MustCompile(`^"(.*)"$`).ReplaceAllString(string(responseData), `$1`)
 		fmt.Printf("name change token %s\n", token)
 		return token, nil
 	}
-	responseData, _ := ioutil.ReadAll(resp.Body)
+	responseData, _ := io.ReadAll(resp.Body)
 	fmt.Printf("name change response %s\n", responseData)
 	defer resp.Body.Close()
 	return "", nil


### PR DESCRIPTION
# Description
This pr removes the deprecated io/ioutil from csi-powerflex

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885 |
| https://github.com/dell/csm/issues/916 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Run cert-csi test and it passed with 100%
```
[2023-08-14 06:37:42]  INFO Avg time of a run:   55.59s
[2023-08-14 06:37:42]  INFO Avg time of a del:   24.97s
[2023-08-14 06:37:42]  INFO Avg time of all:     83.58s
[2023-08-14 06:37:42]  INFO During this run 100.0% of suites succeeded
```
