### PR TITLE
Add k8s1.28 support for csi-powerflex driver.

### DIFF
--- a/dell-csi-helm-installer/csi-install.sh
+++ b/dell-csi-helm-installer/csi-install.sh
@@ -399,8 +399,8 @@ helm --help >&/dev/null || {
 OPENSHIFT=$(isOpenShift)
 
 # Get the kubernetes major and minor version numbers.
-kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
-kMinorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -E 's/.*v([0-9]+)\.[0-9]+\.[0-9]+.*/\1/')
+kMinorVersion=$(run_command kubectl version | grep 'Server Version' |  sed -E 's/.*v[0-9]+\.([0-9]+)\.[0-9]+.*/\1/')
 
 # validate the parameters passed in
 validate_params "${MODE}"

--- a/dell-csi-helm-installer/verify-csi-vxflexos.sh
+++ b/dell-csi-helm-installer/verify-csi-vxflexos.sh
@@ -14,7 +14,7 @@
 
 # verify-csi-vxflexos method
 function verify-csi-vxflexos() {
-  verify_k8s_versions "1.21" "1.27"
+  verify_k8s_versions "1.21" "1.28"
   verify_openshift_versions "4.12" "4.13"
   verify_namespace "${NS}"
   verify_helm_values_version "${DRIVER_VERSION}"

--- a/dell-csi-helm-installer/verify.sh
+++ b/dell-csi-helm-installer/verify.sh
@@ -571,8 +571,8 @@ kubectl --help >&/dev/null || {
 MINION_NODES=$(run_command kubectl get nodes -o wide | grep -v -e master -e INTERNAL | awk ' { print $6; }')
 MASTER_NODES=$(run_command kubectl get nodes -o wide | awk ' /master/{ print $6; }')
 # Get the kubernetes major and minor version numbers.
-kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
-kMinorVersion=$(run_command kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -E 's/.*v([0-9]+)\.[0-9]+\.[0-9]+.*/\1/')
+kMinorVersion=$(run_command kubectl version | grep 'Server Version' |  sed -E 's/.*v[0-9]+\.([0-9]+)\.[0-9]+.*/\1/')
 
 # get the list of valid CSI Drivers, this will be the list of directories in drivers/ that contain helm charts
 get_drivers "${SCRIPTDIR}/../helm"

--- a/helm/csi-vxflexos/Chart.yaml
+++ b/helm/csi-vxflexos/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
 appVersion: "2.7.0"
-kubeVersion: ">= 1.21.0 < 1.28.0"
+kubeVersion: ">= 1.21.0 < 1.29.0"
 # If you are using a complex K8s version like "v1.21.3-mirantis-1", use this kubeVersion check instead
 # WARNING: this version of the check will allow the use of alpha and beta versions, which is NOT SUPPORTED
-# kubeVersion: ">= 1.21.0-0 < 1.28.0-0"
+# kubeVersion: ">= 1.21.0-0 < 1.29.0-0"
 description: |
   VxFlex OS CSI (Container Storage Interface) driver Kubernetes
   integration. This chart includes everything required to provision via CSI as

--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -19,7 +19,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-vxflexos.snapshotterImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-snapshotter:v6.2.2" -}}
     {{- end -}}
   {{- end -}}
@@ -27,7 +27,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-vxflexos.resizerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-resizer:v1.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -35,7 +35,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-vxflexos.registrarImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.8.0" -}}
     {{- end -}}
   {{- end -}}
@@ -43,7 +43,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-vxflexos.healthmonitorImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-external-health-monitor-controller:v0.9.0" -}}
     {{- end -}}
   {{- end -}}

--- a/helm/csi-vxflexos/templates/_helpers.tpl
+++ b/helm/csi-vxflexos/templates/_helpers.tpl
@@ -3,7 +3,7 @@ Return the appropriate sidecar images based on k8s version
 */}}
 {{- define "csi-vxflexos.attacherImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-attacher:v4.3.0" -}}
     {{- end -}}
   {{- end -}}
@@ -11,7 +11,7 @@ Return the appropriate sidecar images based on k8s version
 
 {{- define "csi-vxflexos.provisionerImage" -}}
   {{- if eq .Capabilities.KubeVersion.Major "1" }}
-    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "27") -}}
+    {{- if and (ge (trimSuffix "+" .Capabilities.KubeVersion.Minor) "21") (le (trimSuffix "+" .Capabilities.KubeVersion.Minor) "28") -}}
       {{- print "registry.k8s.io/sig-storage/csi-provisioner:v3.5.0" -}}
     {{- end -}}
   {{- end -}}

--- a/test/helm/common.bash
+++ b/test/helm/common.bash
@@ -25,5 +25,5 @@ waitOnRunning() {
   done
 }
 
-kMajorVersion=$(kubectl version | grep 'Server Version' | sed -e 's/^.*Major:"//' -e 's/[^0-9].*//g')
-kMinorVersion=$(kubectl version | grep 'Server Version' | sed -e 's/^.*Minor:"//' -e 's/[^0-9].*//g')
+kMajorVersion=$(run_command kubectl version | grep 'Server Version' | sed -E 's/.*v([0-9]+)\.[0-9]+\.[0-9]+.*/\1/')
+kMinorVersion=$(run_command kubectl version | grep 'Server Version' |  sed -E 's/.*v[0-9]+\.([0-9]+)\.[0-9]+.*/\1/')

--- a/test/helm/verify_leader_election.sh
+++ b/test/helm/verify_leader_election.sh
@@ -49,7 +49,7 @@ function print_help(){
 # been called. These values change frequently throughout the tests.
 function get_holder() {
 	echo
-	k_version=$(kubectl version |  sed -n '1 p' | grep Minor:\"[0-9][0-9]\" | grep -o \"[0-9][0-9]\" | grep -o [0-9][0-9])
+	k_version=$(kubectl version | grep 'Server Version' |  sed -E 's/.*v[0-9]+\.([0-9]+)\.[0-9]+.*/\1/')
 	holder=$(kubectl get lease -n $NAMESPACE | awk '{print $2}' | sed -n '2 p')
 	restarts=$(kubectl get pods -n $NAMESPACE -o wide | grep $holder | awk '{print $4}')
 	if [ $k_version -ge 22 ] && [ $restarts -gt 0 ]; then


### PR DESCRIPTION
# Description
This pr adds the k8s 1.28 support for csi-powerflex.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/947 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the csi-powerflex on k8s1.28 cluster and Ran cert-csi both are successful
```
root@master-1-HIcOSlrtqK0i1 dell-csi-helm-installer]# ./csi-install.sh --namespace vxflexos --values /root/csm-pipeline/csm-config/drivers/powerflex/values/nightly/nightly-one-controller-plain.yaml --version vmain-latest --skip-verify-node
------------------------------------------------------
> Installing CSI Driver: csi-vxflexos on 1.28
------------------------------------------------------
------------------------------------------------------
> Checking to see if CSI Driver is already installed
------------------------------------------------------
WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/.kube/config
------------------------------------------------------
> Verifying Kubernetes and driver configuration
------------------------------------------------------
|- Kubernetes Version: 1.28
|
|- Driver: csi-vxflexos
|
|- Verifying Kubernetes version
  |
  |--> Verifying minimum Kubernetes version                         Success
  |
  |--> Verifying maximum Kubernetes version                         Success
|
|- Verifying that required namespaces have been created             Success
|
|- Verifying helm values version                                    Success
|
|- Verifying that required secrets have been created                Success
|
|- Verifying alpha snapshot resources
  |
  |--> Verifying that alpha snapshot CRDs are not installed         Success
|
|- Verifying snapshot support
  |
  |--> Verifying that snapshot CRDs are available                   Success
  |
  |--> Verifying that the snapshot controller is available          Success
|
|- Verifying helm version                                           WARNING: Kubernetes configuration file is group-readable. This is insecure. Location: /root/.kube/config
WARNING: Kubernetes configuration file is world-readable. This is insecure. Location: /root/.kube/config
Success

------------------------------------------------------
> Verification Complete - Success
------------------------------------------------------
|
|- Installing Driver                                                |
|- Get SDC config and make MDM string for multi array support       |
|- SDC MDM value created : xxxxxx,xxxxxxxxxxxx              |
|- IP ADDR xxxxxxxxxxxxx format is ok                               |
|- IP ADDR xxxxxxxxxxxxxx format is ok                               Success
  |
  |--> Waiting for Deployment vxflexos-controller to be ready       Success
  |
  |--> Waiting for DaemonSet vxflexos-node to be ready              Success
------------------------------------------------------
> Operation complete
------------------------------------------------------
[root@master-1-HIcOSlrtqK0i1 dell-csi-helm-installer]# k get pods -n vxflexos
NAME                                   READY   STATUS    RESTARTS   AGE
vxflexos-controller-6c4fc64458-8xd7c   5/5     Running   0          17m
vxflexos-controller-6c4fc64458-p98zj   5/5     Running   0          17m
vxflexos-node-qdkj7                    2/2     Running   0          17m
vxflexos-node-z7v9p                    2/2     Running   0          17m

[2023-08-16 05:41:51]  INFO Avg time of a run:   51.46s
[2023-08-16 05:41:51]  INFO Avg time of a del:   16.10s
[2023-08-16 05:41:51]  INFO Avg time of all:     73.26s
[2023-08-16 05:41:51]  INFO During this run 100.0% of suites succeeded
```
