### PR TITLE
Fix nasName default value

### DIFF
--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -24,14 +24,13 @@
   # defines the MDM(s) that SDC should register with on start.
   # Allowed values:  a list of IP addresses or hostnames separated by comma.
   # Default value: none 
-  
+  mdm: "10.0.0.1,10.0.0.2"
   # NFS is only supported on PowerFlex storage system >= 4.0
   # nasName: name of NAS server used for NFS volumes
-  # nasName value must be specified in secret for performing NFS operations.
+  # nasName value must be specified in secret for performing NFS (file) operations.
   # Allowed Values: string
-  # Default Value: None
+  # Default Value: "none"
   nasName: "nas-server"
-
   # nfsAcls: enables setting permissions on NFS mount directory
   # This value will be used if a storage class does not have the NFS ACL (nfsAcls) parameter specified
   # Permissions can be specified in two formats:
@@ -46,8 +45,6 @@
   # Optional: true
   # Default value: "0777"
   # nfsAcls: "0777"  
-
-  mdm: "10.0.0.1,10.0.0.2"
 - username: "admin"
   password: "Password123"
   systemID: "2b11bb111111bb1b"

--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -25,7 +25,7 @@
   # Allowed values:  a list of IP addresses or hostnames separated by comma.
   # Default value: none 
   mdm: "10.0.0.1,10.0.0.2"
-  # NFS is only supported on PowerFlex storage system >= 4.0
+  # NFS is only supported on PowerFlex storage system 4.0.x
   # nasName: name of NAS server used for NFS volumes
   # nasName value must be specified in secret for performing NFS (file) operations.
   # Allowed Values: string

--- a/samples/storageclass/storageclass-nfs.yaml
+++ b/samples/storageclass/storageclass-nfs.yaml
@@ -53,7 +53,7 @@ parameters:
   # Uncomment the line below if you want to use iopsLimit
   # iopsLimit: <IOPS_LIMIT> # Insert iops limit
 
-  # nasName: NAS server's name for NFS voume operations.
+  # nasName: NAS server's name for NFS volume operations.
   # If not specified, value from secret.yaml will be used.
   # If specified in both, secret and storage class, then precedence is given to storage class value.
   # Allowed values: string

--- a/samples/storageclass/storageclass-nfs.yaml
+++ b/samples/storageclass/storageclass-nfs.yaml
@@ -61,14 +61,6 @@ parameters:
   # Default value: None
   nasName: "nas-server"
 
-  # allowRoot: enables or disables root squashing (valid only for NFS)
-  # Allowed values:
-  #   true: will allow root users to use their privileges
-  #   false: will prevent root users on NFS clients from exercising root privileges on the NFS server
-  # Optional: true
-  # Default value: false
-  allowRoot: "false"
-
   # nfsAcls: enables setting permissions on NFS mount directory
   # This value overrides the NFS ACL (nfsAcls) attribute of corresponding array config in secret, if present
   # Permissions can be specified in two formats:

--- a/samples/storageclass/storageclass-nfs.yaml
+++ b/samples/storageclass/storageclass-nfs.yaml
@@ -53,13 +53,14 @@ parameters:
   # Uncomment the line below if you want to use iopsLimit
   # iopsLimit: <IOPS_LIMIT> # Insert iops limit
 
-  # nasName: NAS server's name. If not specified, value from secret.yaml will be used.
+  # nasName: NAS server's name for NFS voume operations.
+  # If not specified, value from secret.yaml will be used.
   # If specified in both, secret and storage class, then precedence is given to storage class value.
   # Allowed values: string
   # Optional: true
   # Default value: None
   nasName: "nas-server"
- 
+
   # allowRoot: enables or disables root squashing (valid only for NFS)
   # Allowed values:
   #   true: will allow root users to use their privileges
@@ -67,7 +68,7 @@ parameters:
   # Optional: true
   # Default value: false
   allowRoot: "false"
-  
+
   # nfsAcls: enables setting permissions on NFS mount directory
   # This value overrides the NFS ACL (nfsAcls) attribute of corresponding array config in secret, if present
   # Permissions can be specified in two formats:

--- a/service/service.go
+++ b/service/service.go
@@ -502,7 +502,7 @@ func (s *service) checkNFS(ctx context.Context, systemID string) (bool, error) {
 		}
 		array := arrayConData[systemID]
 		if array.NasName == nil || *(array.NasName) == "" {
-			return false, fmt.Errorf("nasName value not found in secret, it is mandatory parameter for NFS volume operations")
+			return false, fmt.Errorf("nasName value not found in secret, it is mandatory parameter for NFS volume operations, if not provide the default value 'none'")
 		}
 		return true, nil
 	}

--- a/service/service.go
+++ b/service/service.go
@@ -502,7 +502,7 @@ func (s *service) checkNFS(ctx context.Context, systemID string) (bool, error) {
 		}
 		array := arrayConData[systemID]
 		if array.NasName == nil || *(array.NasName) == "" {
-			return false, fmt.Errorf("nasName value not found in secret, it is mandatory parameter for NFS volume operations, if not provide the default value 'none'")
+			return false, fmt.Errorf("nasName value not found in secret, it is mandatory parameter for NFS volume operations, if not specified, provide the default value as 'none'")
 		}
 		return true, nil
 	}


### PR DESCRIPTION
# Description
This PR includes the fix for default value of nasName key in secret.
It is done for the operations performed on v4.0.x PowerFlex array via CSI-PowerFlex driver.
The default value "none" needs to given in case a user is performing non-NFS related operation on powerflex array v4.0.x where no NAS server is configured.  

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] functional tests
- [x] helm tests for 1vol-nfs for v3.5 and v4.0 arrays
