### PR TITLE
removed the nfsAcls Reference from csi-powerflex.

### DIFF
--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -31,20 +31,6 @@
   # Allowed Values: string
   # Default Value: "none"
   nasName: "nas-server"
-  # nfsAcls: enables setting permissions on NFS mount directory
-  # This value will be used if a storage class does not have the NFS ACL (nfsAcls) parameter specified
-  # Permissions can be specified in two formats:
-  #   1) Unix mode (NFSv3)
-  #   2) NFSv4 ACLs (NFSv4)
-  #      NFSv4 ACLs are supported on NFSv4 share only.
-  # Allowed values:
-  #   1) Unix mode: valid octal mode number
-  #      Examples: "0777", "777", "0755"
-  #   2) NFSv4 acls: valid NFSv4 acls, separated by comma
-  #      Examples: "A::OWNER@:RWX,A::GROUP@:RWX", "A::OWNER@:rxtncy"
-  # Optional: true
-  # Default value: "0777"
-  # nfsAcls: "0777"  
 - username: "admin"
   password: "Password123"
   systemID: "2b11bb111111bb1b"

--- a/samples/storageclass/storageclass-nfs.yaml
+++ b/samples/storageclass/storageclass-nfs.yaml
@@ -61,21 +61,6 @@ parameters:
   # Default value: None
   nasName: "nas-server"
 
-  # nfsAcls: enables setting permissions on NFS mount directory
-  # This value overrides the NFS ACL (nfsAcls) attribute of corresponding array config in secret, if present
-  # Permissions can be specified in two formats:
-  #   1) Unix mode (NFSv3)
-  #   2) NFSv4 ACLs (NFSv4)
-  #      NFSv4 ACLs are supported on NFSv4 share only.
-  # Allowed values:
-  #   1) Unix mode: valid octal mode number
-  #      Examples: "0777", "777", "0755"
-  #   2) NFSv4 acls: valid NFSv4 acls, separated by comma
-  #      Examples: "A::OWNER@:RWX,A::GROUP@:RWX", "A::OWNER@:rxtncy"
-  # Optional: true
-  # Default value: "0777"
-  # nfsAcls: "0777"
-
   # path: relative path to the root of the associated filesystem.
   # Allowed values: string
   # Optional: true

--- a/service/envvars.go
+++ b/service/envvars.go
@@ -58,9 +58,6 @@ const (
 	// EnvReplicationPrefix is used as a prefix to find out if replication is enabled.
 	EnvReplicationPrefix = "X_CSI_REPLICATION_PREFIX" // #nosec G101
 
-	// EnvNfsAcls enables setting permissions on NFS mount directory.
-	EnvNfsAcls = "X_CSI_NFS_ACLS"
-
 	// EnvMaxVolumesPerNode specifies maximum number of volumes that controller can publish to the node.
 	EnvMaxVolumesPerNode = "X_CSI_MAX_VOLUMES_PER_NODE"
 

--- a/service/service.go
+++ b/service/service.go
@@ -108,7 +108,6 @@ type ArrayConnectionData struct {
 	IsDefault                 bool    `json:"isDefault,omitempty"`
 	AllSystemNames            string  `json:"allSystemNames"`
 	NasName                   *string `json:"nasName"`
-	NfsAcls                   string  `json:"nfsAcls"`
 }
 
 // Manifest is the SP's manifest.
@@ -149,7 +148,6 @@ type Opts struct {
 	IsApproveSDCEnabled        bool
 	replicationContextPrefix   string
 	replicationPrefix          string
-	NfsAcls                    string // enables setting permissions on NFS mount directory
 	MaxVolumesPerNode          int64
 	IsQuotaEnabled             bool // allow driver to enable quota limits for NFS volumes
 }
@@ -343,7 +341,6 @@ func (s *service) BeforeServe(
 			"IsSdcRenameEnabled":     s.opts.IsSdcRenameEnabled,
 			"sdcPrefix":              s.opts.SdcPrefix,
 			"IsApproveSDCEnabled":    s.opts.IsApproveSDCEnabled,
-			"nfsAcls":                s.opts.NfsAcls,
 			"MaxVolumesPerNode":      s.opts.MaxVolumesPerNode,
 			"IsQuotaEnabled":         s.opts.IsQuotaEnabled,
 		}
@@ -432,10 +429,6 @@ func (s *service) BeforeServe(
 		opts.MaxVolumesPerNode = 0
 	} else {
 		opts.MaxVolumesPerNode = MaxVolumesPerNode
-	}
-
-	if nfsAcls, ok := csictx.LookupEnv(ctx, EnvNfsAcls); ok {
-		opts.NfsAcls = nfsAcls
 	}
 
 	// log csiNode topology keys
@@ -842,9 +835,6 @@ func getArrayConfig(ctx context.Context) (map[string]*ArrayConnectionData, error
 			if c.NasName == nil || *(c.NasName) == "" {
 				c.NasName = &str
 			}
-			if c.NfsAcls == "" {
-				c.NfsAcls = str
-			}
 
 			skipCertificateValidation := c.SkipCertificateValidation || c.Insecure
 
@@ -857,7 +847,6 @@ func getArrayConfig(ctx context.Context) (map[string]*ArrayConnectionData, error
 				"systemID":                  c.SystemID,
 				"allSystemNames":            c.AllSystemNames,
 				"nasName":                   c.NasName,
-				"nfsAcls":                   c.NfsAcls,
 			}
 
 			Log.WithFields(fields).Infof("configured %s", c.SystemID)

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3017,7 +3017,6 @@ func (f *feature) iCallBeforeServe() error {
 	stringSlice = append(stringSlice, "X_CSI_HEALTH_MONITOR_ENABLED=true")
 	stringSlice = append(stringSlice, "X_CSI_RENAME_SDC_ENABLED=true")
 	stringSlice = append(stringSlice, "X_CSI_RENAME_SDC_PREFIX=test")
-	stringSlice = append(stringSlice, "X_CSI_NFS_ACLS=777")
 	stringSlice = append(stringSlice, "X_CSI_APPROVE_SDC_ENABLED=true")
 	stringSlice = append(stringSlice, "X_CSI_REPLICATION_CONTEXT_PREFIX=test")
 	stringSlice = append(stringSlice, "X_CSI_REPLICATION_PREFIX=test")

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -64,7 +64,6 @@ type ArrayConnectionData struct {
 	IsDefault      bool    `json:"isDefault,omitempty"`
 	AllSystemNames string  `json:"allSystemNames"`
 	NasName        *string `json:"nasname"`
-	NfsAcls        string  `json:"nfsAcls"`
 }
 
 type feature struct {
@@ -183,9 +182,6 @@ func (f *feature) getArrayConfig() (map[string]*ArrayConnectionData, error) {
 			if c.NasName == nil || *(c.NasName) == "" {
 				c.NasName = &str
 			}
-			if c.NfsAcls == "" {
-				c.NfsAcls = str
-			}
 
 			fields := map[string]interface{}{
 				"endpoint":       c.Endpoint,
@@ -196,7 +192,6 @@ func (f *feature) getArrayConfig() (map[string]*ArrayConnectionData, error) {
 				"systemID":       c.SystemID,
 				"allSystemNames": c.AllSystemNames,
 				"nasName":        *c.NasName,
-				"nfsAcls":        c.NfsAcls,
 			}
 
 			fmt.Printf("array found  %s %#v\n", c.SystemID, fields)
@@ -296,10 +291,6 @@ func (f *feature) aBasicNfsVolumeRequest(name string, size int64) error {
 		}
 
 		if val {
-			if a.NasName != nil {
-				params["nasName"] = *a.NasName
-				params["nfsAcls"] = a.NfsAcls
-			}
 			params["storagepool"] = NfsPool
 			params["thickprovisioning"] = "false"
 			if len(f.anotherSystemID) > 0 {
@@ -360,7 +351,6 @@ func (f *feature) aNfsVolumeRequestWithQuota(volname string, volsize int64, path
 		if val {
 			if a.NasName != nil {
 				params["nasName"] = *a.NasName
-				params["nfsAcls"] = a.NfsAcls
 			}
 			params["storagepool"] = NfsPool
 			params["thickprovisioning"] = "false"
@@ -1969,7 +1959,6 @@ func (f *feature) aBasicNfsVolumeRequestWithWrongNasName(name string, size int64
 		if val {
 			if a.NasName != nil {
 				params["nasName"] = wrongNasName
-				params["nfsAcls"] = a.NfsAcls
 			}
 
 			params["storagepool"] = NfsPool
@@ -2096,7 +2085,6 @@ func (f *feature) aNfsVolumeRequest(name string, size int64) error {
 			params := make(map[string]string)
 			if a.NasName != nil {
 				params["nasName"] = *a.NasName
-				params["nfsAcls"] = a.NfsAcls
 			}
 			params["storagepool"] = NfsPool
 			params["thickprovisioning"] = "false"
@@ -2155,7 +2143,6 @@ func (f *feature) controllerPublishVolumeForNfs(id string, nodeIDEnvVar string) 
 		for _, a := range f.arrays {
 			req.VolumeContext = make(map[string]string)
 			req.VolumeContext["nasName"] = *a.NasName
-			req.VolumeContext["nfsAcls"] = a.NfsAcls
 			req.VolumeContext["fsType"] = "nfs"
 			ctx := context.Background()
 			client := csi.NewControllerClient(grpcClient)


### PR DESCRIPTION
# Description
This pr removes the  nfsAcls Reference from csi-powerflex.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/763 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Installed the csi-powerflex driver and the installation is successful.
 ```
    driver:
    Container ID:  containerd://3b4c276e15e6247807c48a613fe6b662a504ad950138685fe108ed31bfe356df
    Image:         xxxxxxxxxx/csi-vxflexos:remove-nfsAcls
    Image ID:      xxxx/csi-vxflexos@sha256:7facbaeabd345003cb167185e510dc8cf5aa1b8361c91f645a97e3a7a1736ba3
    Port:          <none>
    Host Port:     <none>
    Command:
      /csi-vxflexos.sh
    Args:
      --leader-election
      --array-config=/vxflexos-config/config
      --driver-config-params=/vxflexos-config-params/driver-config-params.yaml
    State:          Running
      Started:      Tue, 05 Sep 2023 03:08:28 -0400
    Ready:          True
    Restart Count:  0
    Environment:
      CSI_ENDPOINT:                             /var/run/csi/csi.sock
      X_CSI_MODE:                               controller
      X_CSI_VXFLEXOS_ENABLESNAPSHOTCGDELETE:    false
      X_CSI_VXFLEXOS_ENABLELISTVOLUMESNAPSHOT:  false
      SSL_CERT_DIR:                             /certs
    Mounts:
      /var/run/csi from socket-dir (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-hcf52 (ro)
      /vxflexos-config from vxflexos-config (rw)
      /vxflexos-config-params from vxflexos-config-params (rw)
```
- [x] Ran cert-csi and it passed with 100%
```
[2023-09-05 03:12:04]  INFO Avg time of a run:   83.65s
[2023-09-05 03:12:04]  INFO Avg time of a del:   12.02s
[2023-09-05 03:12:04]  INFO Avg time of all:     106.48s
[2023-09-05 03:12:04]  INFO During this run 100.0% of suites succeeded
```
