### PR TITLE
Update go mod references for dell-csi-extensions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/dell/dell-csi-extensions/common v1.2.0
 	github.com/dell/dell-csi-extensions/podmon v1.2.0
 	github.com/dell/dell-csi-extensions/replication v1.5.0
-	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.3.0
+	github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1
 	github.com/dell/gocsi v1.8.0
 	github.com/dell/gofsutil v1.13.0
 	github.com/dell/goscaleio v1.12.0

--- a/go.sum
+++ b/go.sum
@@ -108,8 +108,8 @@ github.com/dell/dell-csi-extensions/podmon v1.2.0 h1:bYoTPMz/ILl8+cjK+zkwqX5FfiO
 github.com/dell/dell-csi-extensions/podmon v1.2.0/go.mod h1:MXkd5u3Vt876LEqDeqywlK0Re/IA0FZlHKFWvvdhyzI=
 github.com/dell/dell-csi-extensions/replication v1.5.0 h1:xbnWCmNy/nhh6zdBHyM/UqCh/oBfLFwijdBC7UCNANg=
 github.com/dell/dell-csi-extensions/replication v1.5.0/go.mod h1:puNHmHJWoWeMNj5NXER7oXZtxVnkWZjFNP8mwK0ev18=
-github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.3.0 h1:yXocN5AwXzrJXGvx0a3rcD22mQJ7zFzWfpp+IfNs4nY=
-github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.3.0/go.mod h1:EWT6KIoauXYlcGiss60KwlnTwxFI6KCt3hklW0HZIOc=
+github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1 h1:EQAa1da2njL31ev6pJ6X4KTynKB4qpN6ZcuWYdZ58hI=
+github.com/dell/dell-csi-extensions/volumeGroupSnapshot v1.2.1/go.mod h1:etLWwS1G2IqHDuArHqB0OWQvpdcztuBxopWrRE+mpk0=
 github.com/dell/gocsi v1.8.0 h1:0qsC/Ts6QeAWBBVaQvFrZYBXdoR7bmjrDUb3QpcMfHM=
 github.com/dell/gocsi v1.8.0/go.mod h1:X/8Ll8qqKAKCenmd1gPJMUvUmgY8cK0LiS8Pck12UaU=
 github.com/dell/gofsutil v1.13.0 h1:kAW+3YbO02GMPJTRy5H9hSsYYq4kip9gCAIffMFFOX4=


### PR DESCRIPTION
# Description

- Updated go mod references for dell-csi-extensions to latest ones.
- VolumeGroupSnapshot extension will be updated later when VGS sidecar is updated.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/885 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
