### PR TITLE
Revert "updated GetNodeLabels method"

### DIFF
--- a/service/envvars.go
+++ b/service/envvars.go
@@ -66,7 +66,4 @@ const (
 
 	// EnvExternalAccess is the IP of an additional router you wish to add for nfs export
 	EnvExternalAccess = "X_CSI_POWERFLEX_EXTERNAL_ACCESS"
-
-	// EnvKubeNodeName is the name of the environment variable which stores current kubernetes node name
-	EnvKubeNodeName = "X_CSI_POWERFLEX_KUBE_NODE_NAME"
 )

--- a/service/service.go
+++ b/service/service.go
@@ -154,7 +154,6 @@ type Opts struct {
 	MaxVolumesPerNode          int64
 	IsQuotaEnabled             bool   // allow driver to enable quota limits for NFS volumes
 	ExternalAccess             string // used for adding extra IP/IP range to the NFS export
-	KubeNodeName               string
 }
 
 type service struct {
@@ -349,7 +348,6 @@ func (s *service) BeforeServe(
 			"MaxVolumesPerNode":      s.opts.MaxVolumesPerNode,
 			"IsQuotaEnabled":         s.opts.IsQuotaEnabled,
 			"ExternalAccess":         s.opts.ExternalAccess,
-			"KubeNodeName":           s.opts.KubeNodeName,
 		}
 
 		Log.WithFields(fields).Infof("configured %s", Name)
@@ -450,9 +448,6 @@ func (s *service) BeforeServe(
 				opts.ExternalAccess = ""
 			}
 		}
-	}
-	if kubeNodeName, ok := csictx.LookupEnv(ctx, EnvKubeNodeName); ok {
-		opts.KubeNodeName = kubeNodeName
 	}
 
 	// log csiNode topology keys
@@ -1658,9 +1653,13 @@ func (s *service) GetNodeLabels(ctx context.Context) (map[string]string, error) 
 		}
 		K8sClientset = k8sutils.Clientset
 	}
-
+	hostName, ok := os.LookupEnv("HOSTNAME")
+	if !ok {
+		return nil, status.Errorf(codes.FailedPrecondition, "%s not set", "HOSTNAME")
+	}
+	hostName = strings.ToLower(hostName)
 	// access the API to fetch node object
-	node, err := K8sClientset.CoreV1().Nodes().Get(context.TODO(), s.opts.KubeNodeName, v1.GetOptions{})
+	node, err := K8sClientset.CoreV1().Nodes().Get(context.TODO(), hostName, v1.GetOptions{})
 	if err != nil {
 		return nil, status.Error(codes.Internal, GetMessage("Unable to fetch the node labels. Error: %v", err))
 	}

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -1856,7 +1856,7 @@ func mockGetNodeLabelsWithInvalidVolumeLimits(ctx context.Context, s *service) (
 }
 
 func (f *feature) setFakeNode() (*v1.Node, error) {
-	f.service.opts.KubeNodeName = "node1"
+	os.Setenv("HOSTNAME", "node1")
 	fakeNode := &v1.Node{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:   "node1",
@@ -1896,7 +1896,7 @@ func mockLookupEnv(ctx context.Context, key string) (string, bool) {
 }
 
 func (f *feature) iCallGetNodeLabelsWithInvalidNode() error {
-	f.service.opts.KubeNodeName = "node2"
+	os.Setenv("HOSTNAME", "node2")
 	_, f.err = f.service.GetNodeLabels(f.context)
 	return nil
 }


### PR DESCRIPTION
This reverts commit 95eabe5b6b2818de7a8faa2bf44c6d1bba7f4dff.

# Description
Reverts https://github.com/dell/csi-powerflex/pull/274 for v2.9.1

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
