### PR TITLE
Add Multi-Available Zone Functionality

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -177,8 +177,6 @@ func (s *service) CreateVolume(
 		zoneTargetMap = s.getZonesFromSecret()
 	}
 
-	Log.Infof("[CreateVolume] Zone Target Map %+v", zoneTargetMap)
-
 	if len(zoneTargetMap) == 0 {
 		sid, err := s.getSystemIDFromParameters(params)
 		if err != nil {
@@ -262,10 +260,6 @@ func (s *service) CreateVolume(
 		}
 	}
 
-	if systemID == "" {
-		return nil, status.Errorf(codes.InvalidArgument, "no systemID supplied or inferred from Zone")
-	}
-
 	if !zoneTopology && accessibility != nil && len(accessibility.GetPreferred()) > 0 {
 		requestedSystem := ""
 		sID := ""
@@ -328,8 +322,6 @@ func (s *service) CreateVolume(
 			Log.Printf("Accessible topology for volume: %s, segments: %#v", req.GetName(), systemSegments)
 		}
 	}
-
-	Log.Infof("volume topology: %+v", volumeTopology)
 
 	if len(req.VolumeCapabilities) != 0 {
 		if req.VolumeCapabilities[0].GetBlock() != nil {
@@ -2288,13 +2280,9 @@ func (s *service) getCapacityForAllSystems(ctx context.Context, protectionDomain
 		var systemCapacity int64
 		var err error
 
-		Log.Printf("[getCapacityForAllSystems] SP Length: %d", len(spName))
-
 		if len(spName) > 0 && spName[0] != "" {
-			Log.Printf("[getCapacityForAllSystems] Getting system capacity for pool %s", spName[0])
 			systemCapacity, err = s.getSystemCapacity(ctx, array.SystemID, protectionDomain, spName[0])
 		} else {
-			Log.Println("[getCapacityForAllSystems] Getting system capacity for all pools")
 			systemCapacity, err = s.getSystemCapacity(ctx, array.SystemID, "")
 		}
 
@@ -2326,9 +2314,7 @@ func (s *service) GetCapacity(
 
 	systemID := ""
 	params := req.GetParameters()
-
-	Log.Printf("GetCapacity: %v", params)
-	if params == nil || len(params) == 0 {
+	if len(params) == 0 {
 		// Get capacity of all systems
 		capacity, err = s.getCapacityForAllSystems(ctx, "")
 	} else {
@@ -2345,7 +2331,6 @@ func (s *service) GetCapacity(
 		}
 
 		if systemID == "" {
-			Log.Println("[GetCapacity] System ID not found in params")
 			// Get capacity of storage pool spname in all systems, return total capacity
 			capacity, err = s.getCapacityForAllSystems(ctx, "", spname)
 		} else {

--- a/service/controller.go
+++ b/service/controller.go
@@ -241,7 +241,6 @@ func (s *service) CreateVolume(
 	if len(zoneTargetMap) != 0 && accessibility != nil && len(accessibility.GetPreferred()) > 0 {
 		for _, topo := range accessibility.GetPreferred() {
 			for key, value := range topo.Segments {
-				Log.Infof("accessibility preferred segment key %s value %s", key, value)
 				if strings.HasPrefix(key, "zone."+Name) {
 					zoneTarget, ok := zoneTargetMap[value]
 					if !ok {

--- a/service/controller.go
+++ b/service/controller.go
@@ -847,7 +847,7 @@ func (s *service) getZonesFromSecret() map[ZoneName]ZoneContent {
 
 		zone := availabilityZone.Name
 
-		var pd ProtectionDomainName = ""
+		var pd ProtectionDomainName
 		if availabilityZone.ProtectionDomains[0].Name != "" {
 			pd = availabilityZone.ProtectionDomains[0].Name
 		}

--- a/service/features/array-config/config
+++ b/service/features/array-config/config
@@ -1,8 +1,8 @@
 [
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": true,
       "systemID": "14dbbf5617523654",
@@ -10,8 +10,8 @@
    },
    {
       "endpoint": "http://127.0.0.2",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "skipCertificateValidation": true,
       "isDefault": false,
       "systemID": "15dbbf5617523655",

--- a/service/features/array-config/config.2
+++ b/service/features/array-config/config.2
@@ -1,8 +1,8 @@
 [
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": true,
       "systemID": "14dbbf5617523654"
@@ -10,16 +10,16 @@
    },
    {
       "endpoint": "http://127.0.0.2",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": false,
       "systemID": "15dbbf5617523655"
       "nasName": "dummy-nas-server"
    },
    {
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "systemID": "1235e15806d1ec0f",
       "endpoint": "https://1.2.3.4",
       "insecure": true,

--- a/service/features/array-config/duplicate_system_ID
+++ b/service/features/array-config/duplicate_system_ID
@@ -1,6 +1,6 @@
 [
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "DUPLICATE",
         "endpoint": "https://107.0.0.1",
@@ -9,7 +9,7 @@
         "mdm": "10.0.0.1"
     },
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "DUPLICATE",
         "endpoint": "https://107.0.0.1",

--- a/service/features/array-config/invalid_endpoint
+++ b/service/features/array-config/invalid_endpoint
@@ -1,7 +1,7 @@
 [
     {
         "endpoint": "",
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "insecure": true,
         "isDefault": true,

--- a/service/features/array-config/invalid_multi_az
+++ b/service/features/array-config/invalid_multi_az
@@ -1,0 +1,21 @@
+[
+   {
+      "endpoint": "http://127.0.0.1",
+      "username": "admin",
+      "password": "Password123",
+      "insecure": true,
+      "isDefault": true,
+      "systemID": "14dbbf5617523654",
+      "zone": {
+         "name": "notExistent",
+         "protectionDomains": [
+            {
+               "name": "bad",
+               "pools": [
+                  "badPool"
+               ]
+            }
+         ]
+      }
+   }
+]

--- a/service/features/array-config/invalid_multi_az
+++ b/service/features/array-config/invalid_multi_az
@@ -1,8 +1,8 @@
 [
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": true,
       "systemID": "14dbbf5617523654",

--- a/service/features/array-config/invalid_password
+++ b/service/features/array-config/invalid_password
@@ -1,7 +1,7 @@
 [
     {
         "endpoint": "http://127.0.0.1",
-        "username": "admin",
+        "username": "username",
         "password": "",
         "insecure": true,
         "isDefault": true,

--- a/service/features/array-config/invalid_system_name
+++ b/service/features/array-config/invalid_system_name
@@ -1,8 +1,8 @@
 [
     {
         "endpoint": "http://127.0.0.1",
-        "username": "admin",
-        "password": "Password123",
+        "username": "username",
+        "password": "password",
         "insecure": true,
         "isDefault": true,
         "systemID": ""

--- a/service/features/array-config/invalid_username
+++ b/service/features/array-config/invalid_username
@@ -2,7 +2,7 @@
     {
         "endpoint": "http://127.0.0.1",
         "username": "",
-        "password": "Password123",
+        "password": "password",
         "insecure": true,
         "isDefault": true,
         "systemID": "123"

--- a/service/features/array-config/multi_az
+++ b/service/features/array-config/multi_az
@@ -1,0 +1,40 @@
+[
+   {
+      "endpoint": "http://127.0.0.1",
+      "username": "admin",
+      "password": "Password123",
+      "insecure": true,
+      "isDefault": true,
+      "systemID": "14dbbf5617523654",
+      "zone": {
+         "name": "zoneA",
+         "protectionDomains": [
+            {
+               "name": "mocksystem",
+               "pools": [
+                  "viki_pool_HDD_20181031"
+               ]
+            }
+         ]
+      }
+   },
+   {
+      "endpoint": "http://127.0.0.2",
+      "username": "admin",
+      "password": "Password123",
+      "skipCertificateValidation": true,
+      "isDefault": false,
+      "systemID": "15dbbf5617523655",
+      "zone": {
+         "name": "zoneB",
+         "protectionDomains": [
+            {
+               "name": "mocksystem",
+               "pools": [
+                  "viki_pool_HDD_20181031"
+               ]
+            }
+         ]
+      }
+   }
+]

--- a/service/features/array-config/multi_az
+++ b/service/features/array-config/multi_az
@@ -1,8 +1,8 @@
 [
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": true,
       "systemID": "14dbbf5617523654",
@@ -20,8 +20,8 @@
    },
    {
       "endpoint": "http://127.0.0.2",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "skipCertificateValidation": true,
       "isDefault": false,
       "systemID": "15dbbf5617523655",

--- a/service/features/array-config/replication-config
+++ b/service/features/array-config/replication-config
@@ -1,16 +1,16 @@
 [
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "insecure": true,
       "isDefault": true,
       "systemID": "14dbbf5617523654"
    },
    {
       "endpoint": "http://127.0.0.1",
-      "username": "admin",
-      "password": "Password123",
+      "username": "username",
+      "password": "password",
       "skipCertificateValidation": true,
       "isDefault": false,
       "systemID": "15dbbf5617523655"

--- a/service/features/array-config/two_default_array
+++ b/service/features/array-config/two_default_array
@@ -1,6 +1,6 @@
 [
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "321",
         "endpoint": "https://107.0.0.1",
@@ -9,7 +9,7 @@
         "mdm": "10.0.0.1"
     },
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "123",
         "endpoint": "https://107.0.0.2",

--- a/service/features/get_storage_pool_instances.json
+++ b/service/features/get_storage_pool_instances.json
@@ -10,7 +10,7 @@
     "zeroPaddingEnabled": true,
     "backgroundScannerMode": "Disabled",
     "rebalanceIoPriorityPolicy": "favorAppIos",
-    "protectionDomainId": "b8b3919900000000",
+    "protectionDomainId": "14dbbf5617523654",
     "backgroundScannerBWLimitKBps": 0,
     "rebuildIoPriorityBwLimitPerDeviceInKbps": 10240,
     "sparePercentage": 10,

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1551,5 +1551,20 @@ Feature: VxFlex OS CSI interface
     Examples:
       |  systemid                  | nasserver                                |   error                         |  errorMsg                   |
       |  "15dbbf5617523655"        | "63ec8e0d-4551-29a7-e79c-b202f2b914f3"   |   ""                            | "none"                      |   
-      |  "15dbbf5617523655"        | "invalid-nas-server"                     |   "NasNotFoundError"            |  "NAS server not found"     |      
-     
+      |  "15dbbf5617523655"        | "invalid-nas-server"                     |   "NasNotFoundError"            |  "NAS server not found"     |  
+  
+  Scenario: Create Volume for multi-available zone
+    Given a VxFlexOS service
+    And I use config <config>
+    When I call Probe
+    And I call CreateVolume <name> with zones
+    Then the error contains <errorMsg>
+    Examples:
+      | name      | config             | errorMsg                                               |
+      | "volume1" | "multi_az"         | "none"                                                 |
+      | "volume1" | "invalid_multi_az" | "no zone topology found in accessibility requirements" |
+
+  Scenario: Call NodeGetInfo with zone label
+    Given a VxFlexOS service
+    When I call NodeGetInfo with zone labels
+    Then a valid NodeGetInfo is returned with node topology 

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1566,5 +1566,6 @@ Feature: VxFlex OS CSI interface
 
   Scenario: Call NodeGetInfo with zone label
     Given a VxFlexOS service
+    And I use config "multi_az"
     When I call NodeGetInfo with zone labels
     Then a valid NodeGetInfo is returned with node topology 

--- a/service/node.go
+++ b/service/node.go
@@ -779,6 +779,8 @@ func (s *service) NodeGetInfo(
 		topology["zone."+Name] = labels["zone."+Name]
 	}
 
+	Log.Infof("[NodeGetInfo] Topology: %v\n", topology)
+
 	nodeID, err := GetNodeUID(ctx, s)
 	if err != nil {
 		return nil, status.Error(codes.InvalidArgument, GetMessage("Could not fetch node UID"))

--- a/service/node.go
+++ b/service/node.go
@@ -728,15 +728,20 @@ func (s *service) NodeGetInfo(
 		}
 	}
 
+	labels, err := GetNodeLabels(ctx, s)
+	if err != nil {
+		return nil, err
+	}
+
 	var maxVxflexosVolumesPerNode int64
 	if len(connectedSystemID) != 0 {
 		// Check for node label 'max-vxflexos-volumes-per-node'. If present set 'MaxVolumesPerNode' to this value.
 		// If node label is not present, set 'MaxVolumesPerNode' to default value i.e., 0
 
-		labels, err := GetNodeLabels(ctx, s)
-		if err != nil {
-			return nil, err
-		}
+		// labels, err := GetNodeLabels(ctx, s)
+		// if err != nil {
+		// 	return nil, err
+		// }
 
 		if val, ok := labels[maxVxflexosVolumesPerNodeLabel]; ok {
 			maxVxflexosVolumesPerNode, err = strconv.ParseInt(val, 10, 64)
@@ -768,6 +773,10 @@ func (s *service) NodeGetInfo(
 			topology[Name+"/"+array.SystemID+"-nfs"] = "true"
 		}
 		topology[Name+"/"+array.SystemID] = SystemTopologySystemValue
+	}
+
+	if labels["zone."+Name] != "" {
+		topology["zone."+Name] = labels["zone."+Name]
 	}
 
 	nodeID, err := GetNodeUID(ctx, s)

--- a/service/node.go
+++ b/service/node.go
@@ -737,12 +737,6 @@ func (s *service) NodeGetInfo(
 	if len(connectedSystemID) != 0 {
 		// Check for node label 'max-vxflexos-volumes-per-node'. If present set 'MaxVolumesPerNode' to this value.
 		// If node label is not present, set 'MaxVolumesPerNode' to default value i.e., 0
-
-		// labels, err := GetNodeLabels(ctx, s)
-		// if err != nil {
-		// 	return nil, err
-		// }
-
 		if val, ok := labels[maxVxflexosVolumesPerNodeLabel]; ok {
 			maxVxflexosVolumesPerNode, err = strconv.ParseInt(val, 10, 64)
 			if err != nil {
@@ -778,8 +772,6 @@ func (s *service) NodeGetInfo(
 	if labels["zone."+Name] != "" {
 		topology["zone."+Name] = labels["zone."+Name]
 	}
-
-	Log.Infof("[NodeGetInfo] Topology: %v\n", topology)
 
 	nodeID, err := GetNodeUID(ctx, s)
 	if err != nil {

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -4253,12 +4253,15 @@ func (f *feature) iUseConfig(filename string) error {
 	fmt.Printf("****************************************************** s.opts.arrays %v\n", f.service.opts.arrays)
 	f.service.systemProbeAll(context.Background())
 	f.adminClient = f.service.adminClients[arrayID]
-	f.adminClient2 = f.service.adminClients[arrayID2]
 	if f.adminClient == nil {
 		return fmt.Errorf("adminClient nil")
 	}
-	if f.adminClient2 == nil {
-		return fmt.Errorf("adminClient2 nil")
+
+	if len(f.service.opts.arrays) > 1 {
+		f.adminClient2 = f.service.adminClients[arrayID2]
+		if f.adminClient2 == nil {
+			return fmt.Errorf("adminClient2 nil")
+		}
 	}
 	return nil
 }
@@ -4674,6 +4677,76 @@ func (f *feature) iCallPingNASServer(systemID string, name string) error {
 	return nil
 }
 
+func getZoneEnabledRequest() *csi.CreateVolumeRequest {
+	req := new(csi.CreateVolumeRequest)
+	params := make(map[string]string)
+	req.Parameters = params
+	capacityRange := new(csi.CapacityRange)
+	capacityRange.RequiredBytes = 32 * 1024 * 1024 * 1024
+	req.CapacityRange = capacityRange
+	req.AccessibilityRequirements = new(csi.TopologyRequirement)
+	topologies := []*csi.Topology{
+		{
+			Segments: map[string]string{
+				"zone.csi-vxflexos.dellemc.com": "zoneA",
+			},
+		},
+		{
+			Segments: map[string]string{
+				"zone.csi-vxflexos.dellemc.com": "zoneB",
+			},
+		},
+	}
+	req.AccessibilityRequirements.Preferred = topologies
+	return req
+}
+
+func (f *feature) iCallCreateVolumeWithZones(name string) error {
+	ctx := new(context.Context)
+	if f.createVolumeRequest == nil {
+		req := getZoneEnabledRequest()
+		f.createVolumeRequest = req
+	}
+	req := f.createVolumeRequest
+	req.Name = name
+
+	fmt.Println("I am in iCallCreateVolume fn.....")
+
+	f.createVolumeResponse, f.err = f.service.CreateVolume(*ctx, req)
+	if f.err != nil {
+		log.Printf("CreateVolume called failed: %s\n", f.err.Error())
+	}
+
+	if f.createVolumeResponse != nil {
+		log.Printf("vol id %s\n", f.createVolumeResponse.GetVolume().VolumeId)
+	}
+	return nil
+}
+
+func mockGetNodeLabelsWithZone(_ context.Context, _ *service) (map[string]string, error) {
+	labels := map[string]string{"zone.csi-vxflexos.dellemc.com": "zoneA"}
+	return labels, nil
+}
+
+func (f *feature) iCallNodeGetInfoWithZoneLabels() error {
+	ctx := new(context.Context)
+	req := new(csi.NodeGetInfoRequest)
+	f.service.opts.SdcGUID = "9E56672F-2F4B-4A42-BFF4-88B6846FBFDA"
+	GetNodeLabels = mockGetNodeLabelsWithZone
+	GetNodeUID = mockGetNodeUID
+	f.nodeGetInfoResponse, f.err = f.service.NodeGetInfo(*ctx, req)
+	return nil
+}
+
+func (f *feature) aValidNodeGetInfoIsReturnedWithNodeTopology() error {
+	accessibility := f.nodeGetInfoResponse.GetAccessibleTopology()
+	if _, ok := accessibility.Segments["zone.csi-vxflexos.dellemc.com"]; !ok {
+		return fmt.Errorf("zone not found")
+	}
+
+	return nil
+}
+
 func FeatureContext(s *godog.ScenarioContext) {
 	f := &feature{}
 	s.Step(`^a VxFlexOS service$`, f.aVxFlexOSService)
@@ -4897,6 +4970,10 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^a valid node uid is returned$`, f.aValidNodeUIDIsReturned)
 	s.Step(`^I call GetNodeUID with invalid node$`, f.iCallGetNodeUIDWithInvalidNode)
 	s.Step(`^I call GetNodeUID with unset KubernetesClient$`, f.iCallGetNodeUIDWithUnsetKubernetesClient)
+
+	s.Step(`^I call CreateVolume "([^"]*)" with zones$`, f.iCallCreateVolumeWithZones)
+	s.Step(`^I call NodeGetInfo with zone labels$`, f.iCallNodeGetInfoWithZoneLabels)
+	s.Step(`^a valid NodeGetInfo is returned with node topology$`, f.aValidNodeGetInfoIsReturnedWithNodeTopology)
 
 	s.After(func(ctx context.Context, _ *godog.Scenario, _ error) (context.Context, error) {
 		if f.server != nil {

--- a/test/integration/wrong_config.json
+++ b/test/integration/wrong_config.json
@@ -1,6 +1,6 @@
 [
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "system_name",
         "endpoint": "https://127.0.0.1",
@@ -8,7 +8,7 @@
         "isDefault": true
     },
     {
-        "username": "admin",
+        "username": "username",
         "password": "password",
         "systemID": "system_name",
         "endpoint": "https://127.0.0.1",


### PR DESCRIPTION
# Description
Add the multi-available zone functionality so that volumes and pods are only provisioned and scheduled to a node within the correct zone.

When the zone label has been added to a node, and a storage class is used that defines what zones are compatible, the driver will select the preferred zone and attempt to create and schedule the pod for that zone.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Test storage with storage class that defines two zones (zoneA, zoneB) and ensure that both `immediate` and `waitForConsumer` both work for pod scheduling and volume creation.
- [x] Ensured that a regular storage class (not multi-az enabled) still works as expected.
- [x] Create and run unit tests to ensure different edge cases.

```
PASS
coverage: 90.1% of statements
status 0
ok      github.com/dell/csi-vxflexos/v2/service 196.145s        coverage: 90.1% of statements
```