### PR TITLE
Fix Volume Size Rounding Issue in PowerFlex

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -936,13 +936,17 @@ func validateVolSize(cr *csi.CapacityRange) (int64, error) {
 		sizeB        int64
 	)
 
+	// VxFlexOS creates volumes in multiples of 8GiB, rounding up.
+	// Determine what actual size of volume will be, and check that
+	// we do not exceed maxSize
 	// Calculate size in GiB using float for precision
 	sizeGiBFloat = float64(minSize) / float64(kiBytesInGiB)
 
 	// Use math.Ceil to round up to the nearest whole GiB
 	sizeGiB = int64(math.Ceil(sizeGiBFloat))
 
-	// Ensure at least 1 GiB for rounding
+	// if the requested size was less than 1GB, set the request to 1GB
+	// so it can be rounded to a 8GiB boundary correctly
 	if sizeGiB < 1 {
 		sizeGiB = 1
 	}

--- a/service/controller.go
+++ b/service/controller.go
@@ -979,16 +979,17 @@ func validateVolSize(cr *csi.CapacityRange) (int64, error) {
 	}
 
 	var (
-		sizeGiB float64
-		sizeKiB int64
-		sizeB   int64
+		sizeGiBFloat float64
+		sizeGiB      int64
+		sizeKiB      int64
+		sizeB        int64
 	)
 
 	// Calculate size in GiB using float for precision
-	sizeGiB = minSize / kiBytesInGiB
+	sizeGiBFloat = float64(minSize) / float64(kiBytesInGiB)
 
 	// Use math.Ceil to round up to the nearest whole GiB
-	sizeGiB := int64(math.Ceil(sizeGiBFloat))
+	sizeGiB = int64(math.Ceil(sizeGiBFloat))
 
 	// Ensure at least 1 GiB for rounding
 	if sizeGiB < 1 {

--- a/service/controller.go
+++ b/service/controller.go
@@ -914,68 +914,19 @@ func (s *service) clearCache() {
 // validateVolSize uses the CapacityRange range params to determine what size
 // volume to create, and returns an error if volume size would be greater than
 // the given limit. Returned size is in KiB
-// func validateVolSize(cr *csi.CapacityRange) (int64, error) {
-// 	minSize := cr.GetRequiredBytes()
-// 	maxSize := cr.GetLimitBytes()
-// 	if minSize < 0 || maxSize < 0 {
-// 		return 0, status.Errorf(
-// 			codes.OutOfRange,
-// 			"bad capacity: volume size bytes %d and limit size bytes: %d must not be negative", minSize, maxSize)
-// 	}
-
-// 	if minSize == 0 {
-// 		minSize = DefaultVolumeSizeKiB
-// 	} else {
-// 		minSize = minSize / bytesInKiB
-// 	}
-
-// 	var (
-// 		sizeGiB int64
-// 		sizeKiB int64
-// 		sizeB   int64
-// 	)
-// 	// VxFlexOS creates volumes in multiples of 8GiB, rounding up.
-// 	// Determine what actual size of volume will be, and check that
-// 	// we do not exceed maxSize
-// 	sizeGiB = minSize / kiBytesInGiB
-// 	// if the requested size was less than 1GB, set the request to 1GB
-// 	// so it can be rounded to a 8GiB boundary correctly
-// 	if sizeGiB == 0 {
-// 		sizeGiB = 1
-// 	}
-// 	mod := sizeGiB % VolSizeMultipleGiB
-// 	if mod > 0 {
-// 		sizeGiB = sizeGiB - mod + VolSizeMultipleGiB
-// 	}
-// 	sizeB = sizeGiB * bytesInGiB
-// 	if maxSize != 0 {
-// 		if sizeB > maxSize {
-// 			return 0, status.Errorf(
-// 				codes.OutOfRange,
-// 				"bad capacity: volume size %d > limit_bytes: %d", sizeB, maxSize)
-// 		}
-// 	}
-
-// 	sizeKiB = sizeGiB * kiBytesInGiB
-// 	return sizeKiB, nil
-// }
-
 func validateVolSize(cr *csi.CapacityRange) (int64, error) {
 	minSize := cr.GetRequiredBytes()
 	maxSize := cr.GetLimitBytes()
-
-	// Check for negative sizes
 	if minSize < 0 || maxSize < 0 {
 		return 0, status.Errorf(
 			codes.OutOfRange,
 			"bad capacity: volume size bytes %d and limit size bytes: %d must not be negative", minSize, maxSize)
 	}
 
-	// Set default size if minSize is zero
 	if minSize == 0 {
 		minSize = DefaultVolumeSizeKiB
 	} else {
-		minSize = minSize / bytesInKiB // Convert to KiB
+		minSize = minSize / bytesInKiB
 	}
 
 	var (
@@ -995,24 +946,19 @@ func validateVolSize(cr *csi.CapacityRange) (int64, error) {
 	if sizeGiB < 1 {
 		sizeGiB = 1
 	}
-
-	// Round up to the nearest multiple of VolSizeMultipleGiB
 	mod := sizeGiB % VolSizeMultipleGiB
 	if mod > 0 {
 		sizeGiB = sizeGiB - mod + VolSizeMultipleGiB
 	}
-
-	// Convert size to bytes
 	sizeB = sizeGiB * bytesInGiB
-
-	// Check against maxSize
-	if maxSize != 0 && sizeB > maxSize {
-		return 0, status.Errorf(
-			codes.OutOfRange,
-			"bad capacity: volume size %d > limit_bytes: %d", sizeB, maxSize)
+	if maxSize != 0 {
+		if sizeB > maxSize {
+			return 0, status.Errorf(
+				codes.OutOfRange,
+				"bad capacity: volume size %d > limit_bytes: %d", sizeB, maxSize)
+		}
 	}
 
-	// Convert size to KiB for return
 	sizeKiB = sizeGiB * kiBytesInGiB
 	return sizeKiB, nil
 }

--- a/service/service_unit_test.go
+++ b/service/service_unit_test.go
@@ -116,10 +116,10 @@ func TestGetVolSize(t *testing.T) {
 		{
 			// Requesting a size of 8.5 GiB to test rounding up
 			cr: &csi.CapacityRange{
-				RequiredBytes: int64(8.5 * float64(bytesInGiB)),
+				RequiredBytes: int64(48.8 * float64(bytesInGiB)),
 				LimitBytes:    0,
 			},
-			sizeKiB: 16 * kiBytesInGiB,
+			sizeKiB: 56 * kiBytesInGiB,
 		},
 	}
 

--- a/service/service_unit_test.go
+++ b/service/service_unit_test.go
@@ -116,7 +116,7 @@ func TestGetVolSize(t *testing.T) {
 		{
 			// Requesting a size of 8.5 GiB to test rounding up
 			cr: &csi.CapacityRange{
-				RequiredBytes: int64(48.8 * float64(bytesInGiB)),
+				RequiredBytes: int64(48.5 * float64(bytesInGiB)),
 				LimitBytes:    0,
 			},
 			sizeKiB: 56 * kiBytesInGiB,

--- a/service/service_unit_test.go
+++ b/service/service_unit_test.go
@@ -72,7 +72,7 @@ func TestGetVolSize(t *testing.T) {
 		{
 			// requesting a size less than 1GiB should result in a minimal size
 			cr: &csi.CapacityRange{
-				RequiredBytes: 300 * bytesInKiB,
+				RequiredBytes: 1,
 				LimitBytes:    0,
 			},
 			sizeKiB: 8 * kiBytesInGiB,
@@ -104,6 +104,22 @@ func TestGetVolSize(t *testing.T) {
 				LimitBytes:    14 * bytesInGiB,
 			},
 			sizeKiB: 0,
+		},
+		{
+			// Requesting a size with decimal part that rounds up to next multiple of 8 GiB
+			cr: &csi.CapacityRange{
+				RequiredBytes: int64(9.5 * float64(bytesInGiB)),
+				LimitBytes:    0,
+			},
+			sizeKiB: 16 * kiBytesInGiB,
+		},
+		{
+			// Requesting a size of 8.5 GiB to test rounding up
+			cr: &csi.CapacityRange{
+				RequiredBytes: int64(8.5 * float64(bytesInGiB)),
+				LimitBytes:    0,
+			},
+			sizeKiB: 16 * kiBytesInGiB,
 		},
 	}
 
@@ -628,111 +644,6 @@ func TestFindNetworkInterfaceIPs(t *testing.T) {
 			tt.createConfigMap(tt.configMapData, tt.client)
 			_, err := s.findNetworkInterfaceIPs()
 			assert.Equal(t, err, tt.expectedError)
-		})
-	}
-}
-
-func TestValidateVolSize(t *testing.T) {
-	tests := []struct {
-		cr              *csi.CapacityRange
-		expectedSizeKiB int64
-		expectError     bool
-	}{
-		{
-			// No required or limit bytes should return the default size
-			cr: &csi.CapacityRange{
-				RequiredBytes: 0,
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: DefaultVolumeSizeKiB,
-			expectError:     false,
-		},
-		{
-			// Requesting a size less than 1 GiB should round up to 1 GiB
-			cr: &csi.CapacityRange{
-				RequiredBytes: 300 * bytesInKiB,
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: 8 * kiBytesInGiB,
-			expectError:     false,
-		},
-		{
-			// Setting a limit below the default size should result in an error
-			cr: &csi.CapacityRange{
-				RequiredBytes: 0,
-				LimitBytes:    4 * bytesInGiB,
-			},
-			expectedSizeKiB: 0,
-			expectError:     true,
-		},
-		{
-			// Requesting a size that is not a multiple of 8 GiB should round up
-			cr: &csi.CapacityRange{
-				RequiredBytes: 10 * bytesInGiB,
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: 16 * kiBytesInGiB,
-			expectError:     false,
-		},
-		{
-			// Requesting a size that exceeds the limit should result in an error
-			cr: &csi.CapacityRange{
-				RequiredBytes: 13 * bytesInGiB,
-				LimitBytes:    14 * bytesInGiB,
-			},
-			expectedSizeKiB: 0,
-			expectError:     true,
-		},
-		{
-			// Negative required bytes should return an error
-			cr: &csi.CapacityRange{
-				RequiredBytes: -1,
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: 0,
-			expectError:     true,
-		},
-		{
-			// Negative limit bytes should return an error
-			cr: &csi.CapacityRange{
-				RequiredBytes: 0,
-				LimitBytes:    -1,
-			},
-			expectedSizeKiB: 0,
-			expectError:     true,
-		},
-		{
-			// Requesting a size with decimal part that rounds up to next multiple of 8 GiB
-			cr: &csi.CapacityRange{
-				RequiredBytes: int64(9.5 * float64(bytesInGiB)),
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: 16 * kiBytesInGiB,
-			expectError:     false,
-		},
-		{
-			// Requesting a size of 8.5 GiB to test rounding up
-			cr: &csi.CapacityRange{
-				RequiredBytes: int64(8.5 * float64(bytesInGiB)),
-				LimitBytes:    0,
-			},
-			expectedSizeKiB: 16 * kiBytesInGiB,
-			expectError:     false,
-		},
-	}
-
-	for _, tt := range tests {
-		tt := tt // Capture range variable
-		t.Run("", func(st *testing.T) {
-			st.Parallel()
-			sizeKiB, err := validateVolSize(tt.cr)
-			if tt.expectError {
-				assert.Error(st, err)
-				assert.EqualValues(st, tt.expectedSizeKiB, sizeKiB)
-			} else {
-				assert.NoError(st, err)
-				assert.EqualValues(st, tt.expectedSizeKiB, sizeKiB)
-			}
 		})
 	}
 }

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3421,28 +3421,28 @@ func (f *feature) aCorrectNodeGetVolumeStatsResponse() error {
 	return nil
 }
 
-func (f *feature) iCallNodeUnstageVolumeWith(error string) error {
+func (f *feature) iCallNodeUnstageVolumeWith(errStr string) error {
 	// Save the ephemeralStagingMountPath to restore below
 	ephemeralPath := ephemeralStagingMountPath
 	header := metadata.New(map[string]string{"csi.requestid": "1"})
-	if error == "NoRequestID" {
+	if errStr == "NoRequestID" {
 		header = metadata.New(map[string]string{"csi.requestid": ""})
 	}
 	ctx := metadata.NewIncomingContext(context.Background(), header)
 	req := new(csi.NodeUnstageVolumeRequest)
 	req.VolumeId = goodVolumeID
-	if error == "NoVolumeID" {
+	if errStr == "NoVolumeID" {
 		req.VolumeId = ""
 	}
 	req.StagingTargetPath = datadir
-	if error == "NoStagingTarget" {
+	if errStr == "NoStagingTarget" {
 		req.StagingTargetPath = ""
 	}
-	if error == "UnmountError" {
+	if errStr == "UnmountError" {
 		req.StagingTargetPath = "/tmp"
 		gofsutil.GOFSMock.InduceUnmountError = true
 	}
-	if error == "EphemeralVolume" {
+	if errStr == "EphemeralVolume" {
 		// Create an ephemeral volume id
 		ephemeralStagingMountPath = "test/"
 		err := os.MkdirAll("test"+"/"+goodVolumeID+"/id", 0o777)

--- a/test/integration/features/integration.feature
+++ b/test/integration/features/integration.feature
@@ -37,6 +37,15 @@ Feature: VxFlex OS CSI interface
     And when I call DeleteVolume
     Then there are no errors
 
+  Scenario: Create and delete basic volume with float size
+    Given a VxFlexOS service
+    And a basic block volume request "integration1" "48.1"
+    When I call CreateVolume
+    When I call ListVolume
+    Then a valid ListVolumeResponse is returned
+    And when I call DeleteVolume
+    Then there are no errors
+
   Scenario: Idempotent create and delete basic volume
     Given a VxFlexOS service
     And a basic block volume request "integration2" "8"

--- a/test/integration/step_defs_test.go
+++ b/test/integration/step_defs_test.go
@@ -331,7 +331,7 @@ func (f *feature) aVxFlexOSService() error {
 	return nil
 }
 
-func (f *feature) aBasicBlockVolumeRequest(name string, size int64) error {
+func (f *feature) aBasicBlockVolumeRequest(name string, size float64) error {
 	req := new(csi.CreateVolumeRequest)
 	storagePool := os.Getenv("STORAGE_POOL")
 	params := make(map[string]string)
@@ -344,7 +344,7 @@ func (f *feature) aBasicBlockVolumeRequest(name string, size int64) error {
 	makeAUniqueName(&name)
 	req.Name = name
 	capacityRange := new(csi.CapacityRange)
-	capacityRange.RequiredBytes = size * 1024 * 1024 * 1024
+	capacityRange.RequiredBytes = int64(math.Ceil(size * 1024 * 1024 * 1024))
 	req.CapacityRange = capacityRange
 	capability := new(csi.VolumeCapability)
 	block := new(csi.VolumeCapability_BlockVolume)
@@ -2737,7 +2737,7 @@ func (f *feature) checkNFS(_ context.Context, systemID string) (bool, error) {
 func FeatureContext(s *godog.ScenarioContext) {
 	f := &feature{}
 	s.Step(`^a VxFlexOS service$`, f.aVxFlexOSService)
-	s.Step(`^a basic block volume request "([^"]*)" "(\d+)"$`, f.aBasicBlockVolumeRequest)
+	s.Step(`^a basic block volume request "([^"]*)" "(\d+(\.\d+)?)"$`, f.aBasicBlockVolumeRequest)
 	s.Step(`^Set System Name As "([^"]*)"$`, f.iSetSystemName)
 	s.Step(`^Set Bad AllSystemNames$`, f.iSetBadAllSystemNames)
 	s.Step(`^I call CreateVolume$`, f.iCallCreateVolume)


### PR DESCRIPTION
# Description
When creating a volume in PowerFlex, it appears to round down instead of up for sizes that are multiples of 8GB, fixing this issue.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1608

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have verified that new and existing unit tests pass locally with my changes
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] Backward compatibility is not broken

# How Has This Been Tested?
 1. Deployed the driver using csm-operator, created a PVC with a storage size of 51200000Ki, it correctly rounds up to 56 GiB. Previously, it rounded down to 48 GiB.
 2. Added and executed UT
 3. Executed cert-csi
 [pflex-cert-csi.txt](https://github.com/user-attachments/files/17933983/pflex-cert-csi.txt)
 
[pflex-integration.txt](https://github.com/user-attachments/files/17987673/pflex-integration.txt)

