### PR TITLE
Use generic zone labels

### DIFF
--- a/samples/secret.yaml
+++ b/samples/secret.yaml
@@ -44,6 +44,9 @@
   #   # name: The name of the container orchestrator's availability zone to which the PowerFlex system
   #   # should be mapped.
   #   name: "zoneA"
+  #   # labelKey: The name of the label used for the availability zone to which the PowerFlex system
+  #   # should be mapped.
+  #   labelKey: "topology.kubernetes.io/zone"
   #   # protectionDomains: A list of the protection domains and their associated pools, defined in
   #   # the PowerFlex system.
   #   # Currently, csi-powerflex only supports one protection domain per zone.

--- a/service/controller.go
+++ b/service/controller.go
@@ -219,11 +219,12 @@ func (s *service) CreateVolume(
 	var volumeTopology []*csi.Topology
 	systemSegments := map[string]string{} // topology segments matching requested system for a volume
 
-	// Handle Zone topology, which happens when node is annotated with "Zone" label
+	// Handle Zone topology, which happens when node is annotated with a matching zone label
 	if len(zoneTargetMap) != 0 && accessibility != nil && len(accessibility.GetPreferred()) > 0 {
 		for _, topo := range accessibility.GetPreferred() {
 			for topoLabel, zoneName := range topo.Segments {
-				if strings.HasPrefix(topoLabel, "zone."+Name) {
+				Log.Infof("Zoning based on label %s", s.opts.zoneLabelKey)
+				if strings.HasPrefix(topoLabel, s.opts.zoneLabelKey) {
 					zoneTarget, ok := zoneTargetMap[ZoneName(zoneName)]
 					if !ok {
 						Log.Infof("no zone target for %s", zoneTarget)
@@ -241,7 +242,7 @@ func (s *service) CreateVolume(
 						continue
 					}
 
-					systemSegments["zone."+Name] = zoneName
+					systemSegments[s.opts.zoneLabelKey] = zoneName
 					volumeTopology = append(volumeTopology, &csi.Topology{
 						Segments: systemSegments,
 					})

--- a/service/features/array-config/multi_az
+++ b/service/features/array-config/multi_az
@@ -8,6 +8,7 @@
       "systemID": "14dbbf5617523654",
       "zone": {
          "name": "zoneA",
+         "labelKey": "zone.csi-vxflexos.dellemc.com",
          "protectionDomains": [
             {
                "name": "mocksystem",
@@ -27,6 +28,7 @@
       "systemID": "15dbbf5617523655",
       "zone": {
          "name": "zoneB",
+         "labelKey": "zone.csi-vxflexos.dellemc.com",
          "protectionDomains": [
             {
                "name": "mocksystem",

--- a/service/features/array-config/multi_az_custom_labels
+++ b/service/features/array-config/multi_az_custom_labels
@@ -1,0 +1,22 @@
+[
+   {
+      "endpoint": "http://127.0.0.1",
+      "username": "username",
+      "password": "password",
+      "insecure": true,
+      "isDefault": true,
+      "systemID": "14dbbf5617523654",
+      "zone": {
+         "name": "zone1",
+         "labelKey": "topology.k8s.io/zone",
+         "protectionDomains": [
+            {
+               "name": "pd",
+               "pools": [
+                  "pool1"
+               ]
+            }
+         ]
+      }
+   }
+]

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1572,12 +1572,10 @@ Feature: VxFlex OS CSI interface
 
   Scenario: Call NodeGetInfo with zone label
     Given a VxFlexOS service
-    And I use config "multi_az"
+    And I use config <config>
     When I call NodeGetInfo with zone labels
     Then a valid NodeGetInfo is returned with node topology
-
-  Scenario: Call NodeGetInfo with zone label with invalid config
-    Given a VxFlexOS service
-    And I use config "multi_az_custom_labels"
-    When I call NodeGetInfo with zone labels
-    Then a valid NodeGetInfo is returned with node topology
+    Examples:
+      | config             |
+      | "multi_az"         |
+      | "multi_az_custom_labels" |

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1578,6 +1578,6 @@ Feature: VxFlex OS CSI interface
 
   Scenario: Call NodeGetInfo with zone label with invalid config
     Given a VxFlexOS service
-    And I use config "invalid_multi_az"
+    And I use config "multi_az_custom_labels"
     When I call NodeGetInfo with zone labels
-    Then a NodeGetInfo is returned without zone system topology
+    Then a valid NodeGetInfo is returned with node topology

--- a/service/node.go
+++ b/service/node.go
@@ -758,8 +758,9 @@ func (s *service) NodeGetInfo(
 	// csi-vxflexos.dellemc.com/<systemID>: <provisionerName>
 	Log.Infof("Arrays: %+v", s.opts.arrays)
 	topology := map[string]string{}
-	if zone, ok := labels["zone."+Name]; ok {
-		topology["zone."+Name] = zone
+
+	if zone, ok := labels[s.opts.zoneLabelKey]; ok {
+		topology[s.opts.zoneLabelKey] = zone
 	}
 
 	for _, array := range s.opts.arrays {
@@ -772,7 +773,7 @@ func (s *service) NodeGetInfo(
 			topology[Name+"/"+array.SystemID+"-nfs"] = "true"
 		}
 
-		if zone, ok := topology["zone."+Name]; ok {
+		if zone, ok := topology[s.opts.zoneLabelKey]; ok {
 			if zone == string(array.AvailabilityZone.Name) {
 				// Add only the secret values with the correct zone.
 				nodeID, _ := GetNodeUID(ctx, s)

--- a/service/service_unit_test.go
+++ b/service/service_unit_test.go
@@ -575,7 +575,11 @@ func TestGetZoneKeyLabelFromSecret(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			label, err := getZoneKeyLabelFromSecret(tt.arrays)
-			assert.Equal(t, err, tt.expectedErr)
+			if tt.expectedErr == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.NotNil(t, err)
+			}
 			assert.Equal(t, label, tt.expectedLabel)
 		})
 	}

--- a/service/service_unit_test.go
+++ b/service/service_unit_test.go
@@ -517,6 +517,70 @@ func TestGetIPAddressByInterface(t *testing.T) {
 	}
 }
 
+func TestGetZoneKeyLabelFromSecret(t *testing.T) {
+	tests := []struct {
+		name          string
+		arrays        map[string]*ArrayConnectionData
+		expectedLabel string
+		expectedErr   error
+	}{
+		{
+			name:          "Empty array connection data",
+			arrays:        map[string]*ArrayConnectionData{},
+			expectedLabel: "",
+			expectedErr:   nil,
+		},
+		{
+			name: "Array connection data with same zone label keys",
+			arrays: map[string]*ArrayConnectionData{
+				"array1": {
+					AvailabilityZone: &AvailabilityZone{
+						Name:     "zone1",
+						LabelKey: "custom-zone.io/area",
+					},
+				},
+				"array2": {
+					AvailabilityZone: &AvailabilityZone{
+						Name:     "zone2",
+						LabelKey: "custom-zone.io/area",
+					},
+				},
+			},
+			expectedLabel: "custom-zone.io/area",
+			expectedErr:   nil,
+		},
+		{
+			name: "Array connection data with different label keys",
+			arrays: map[string]*ArrayConnectionData{
+				"array1": {
+					SystemID: "system-1",
+					AvailabilityZone: &AvailabilityZone{
+						Name:     "zone1",
+						LabelKey: "custom-zone-1.io/area",
+					},
+				},
+				"array2": {
+					SystemID: "system-2",
+					AvailabilityZone: &AvailabilityZone{
+						Name:     "zone2",
+						LabelKey: "custom-zone-2.io/area",
+					},
+				},
+			},
+			expectedLabel: "",
+			expectedErr:   fmt.Errorf("array system-2 zone key custom-zone-2.io/area does not match custom-zone-1.io/area"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			label, err := getZoneKeyLabelFromSecret(tt.arrays)
+			assert.Equal(t, err, tt.expectedErr)
+			assert.Equal(t, label, tt.expectedLabel)
+		})
+	}
+}
+
 func TestFindNetworkInterfaceIPs(t *testing.T) {
 	tests := []struct {
 		name            string

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -4251,6 +4251,10 @@ func (f *feature) iUseConfig(filename string) error {
 		}
 	}
 
+	f.service.opts.zoneLabelKey, err = getZoneKeyLabelFromSecret(f.service.opts.arrays)
+	if err != nil {
+		return fmt.Errorf("get zone key label from secret: %s", err.Error())
+	}
 	fmt.Printf("****************************************************** s.opts.arrays %v\n", f.service.opts.arrays)
 	f.service.systemProbeAll(context.Background())
 	f.adminClient = f.service.adminClients[arrayID]


### PR DESCRIPTION
# Description
Allow custom zone labels to be used for topology. Instead of requiring the zone label to be zone.csi-vxflexos.dellemc.com, the customer can now provide a custom label.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1612 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Deployed driver on a k8s cluster with 2 zones. Used custom labels and verified provisioning and cert-csi tests were successful.