### PR TITLE
Add Snapshot and Clone Support for Multi-Available Zone

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1579,3 +1579,29 @@ Feature: VxFlex OS CSI interface
       | config             |
       | "multi_az"         |
       | "multi_az_custom_labels" |
+  
+  Scenario: Snapshot a single volume in zone
+    Given a VxFlexOS service
+    And I use config <config>
+    When I call Probe
+    And I call CreateVolume "volume1" with zones
+    And a valid CreateVolumeResponse is returned
+    And I call CreateSnapshot <name>
+    Then a valid CreateSnapshotResponse is returned
+    And I call Create Volume for zones from Snapshot <name>
+    Then a valid CreateVolumeResponse is returned
+    Examples:
+      | name      | config             | errorMsg       |    
+      | "snap1"   | "multi_az"         | "none"         |
+      
+  Scenario: Clone a single volume in zone
+    Given a VxFlexOS service
+    And I use config <config>
+    When I call Probe
+    And I call CreateVolume <name> with zones
+    And a valid CreateVolumeResponse is returned    
+    And I call Clone volume for zones <name>
+    Then a valid CreateVolumeResponse is returned
+    Examples:
+      | name      | config             | errorMsg       |    
+      | "volume1"   | "multi_az"       | "none"         |     

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3812,6 +3812,39 @@ func (f *feature) iCallCreateVolumeFromSnapshot() error {
 	return nil
 }
 
+func (f *feature) iCallCreateVolumeForZonesFromSnapshot(snapshotID string) error {
+	ctx := new(context.Context)
+	req := getZoneEnabledRequest(f.service.opts.zoneLabelKey)
+	req.Name = "volumeForZonesFromSnap "
+
+	source := &csi.VolumeContentSource_SnapshotSource{SnapshotId: snapshotID}
+	req.VolumeContentSource = new(csi.VolumeContentSource)
+	req.VolumeContentSource.Type = &csi.VolumeContentSource_Snapshot{Snapshot: source}
+	f.createVolumeResponse, f.err = f.service.CreateVolume(*ctx, req)
+	if f.err != nil {
+		fmt.Printf("Error on CreateVolume for zones from snap: %s\n", f.err.Error())
+	}
+	return nil
+}
+
+func (f *feature) iCallCloneVolumeForZones(volumeID string) error {
+	ctx := new(context.Context)
+	req := getZoneEnabledRequest(f.service.opts.zoneLabelKey)
+	req.Name = "clone"
+
+	source := &csi.VolumeContentSource_VolumeSource{VolumeId: volumeID}
+	req.VolumeContentSource = new(csi.VolumeContentSource)
+	req.VolumeContentSource.Type = &csi.VolumeContentSource_Volume{Volume: source}
+	req.AccessibilityRequirements = new(csi.TopologyRequirement)
+	fmt.Printf("CallCloneVolumeForZones with request = %v", req)
+	f.createVolumeResponse, f.err = f.service.CreateVolume(*ctx, req)
+	if f.err != nil {
+		fmt.Printf("Error on CreateVolume from volume: %s\n", f.err.Error())
+	}
+
+	return nil
+}
+
 func (f *feature) iCallCreateVolumeFromSnapshotNFS() error {
 	ctx := new(context.Context)
 	req := getTypicalNFSCreateVolumeRequest()
@@ -4685,6 +4718,7 @@ func (f *feature) iCallPingNASServer(systemID string, name string) error {
 func getZoneEnabledRequest(zoneLabelName string) *csi.CreateVolumeRequest {
 	req := new(csi.CreateVolumeRequest)
 	params := make(map[string]string)
+	params["storagepool"] = "viki_pool_HDD_20181031"
 	req.Parameters = params
 	capacityRange := new(csi.CapacityRange)
 	capacityRange.RequiredBytes = 32 * 1024 * 1024 * 1024
@@ -4715,11 +4749,11 @@ func (f *feature) iCallCreateVolumeWithZones(name string) error {
 	req := f.createVolumeRequest
 	req.Name = name
 
-	fmt.Println("I am in iCallCreateVolume fn.....")
+	fmt.Printf("I am in iCallCreateVolume with zones fn with req => ..... %v ...", req)
 
 	f.createVolumeResponse, f.err = f.service.CreateVolume(*ctx, req)
 	if f.err != nil {
-		log.Printf("CreateVolume called failed: %s\n", f.err.Error())
+		log.Printf("CreateVolume with zones called failed: %s\n", f.err.Error())
 	}
 
 	if f.createVolumeResponse != nil {
@@ -4902,6 +4936,8 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^I call DeleteSnapshot NFS$`, f.iCallDeleteSnapshotNFS)
 	s.Step(`^a valid snapshot consistency group$`, f.aValidSnapshotConsistencyGroup)
 	s.Step(`^I call Create Volume from Snapshot$`, f.iCallCreateVolumeFromSnapshot)
+	s.Step(`^I call Create Volume for zones from Snapshot "([^"]*)"$`, f.iCallCreateVolumeForZonesFromSnapshot)
+	s.Step(`^I call Clone volume for zones "([^"]*)"$`, f.iCallCloneVolumeForZones)
 	s.Step(`^I call Create Volume from SnapshotNFS$`, f.iCallCreateVolumeFromSnapshotNFS)
 	s.Step(`^the wrong capacity$`, f.theWrongCapacity)
 	s.Step(`^the wrong storage pool$`, f.theWrongStoragePool)

--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -22,3 +22,4 @@ The following tests are implemented and run during the `zone-e2e` test.
 
 1. Creates a stateful set of 7 replicas and ensures that everything is up and ready with the zone configuration.
 2. Cordons a node (marks it as unschedulable), creates 7 volumes/pods, and ensures that none gets scheduled on the cordoned node.
+3. Creates a stateful set of 7 replicas, creates a snapshot and restore pod for each and ensure that they are all running.

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -350,8 +350,8 @@ func (f *feature) createZoneSnapshotsAndRestore(location string) error {
 	for i := 0; i < int(f.zoneReplicaCount); i++ {
 		time.Sleep(10 * time.Second)
 
-		copyFile := exec.Command("cp", templateFile, updatedTemplateFile)
-		b, err := copyFile.CombinedOutput()
+		cpCmd := "cp " + templateFile + " " + updatedTemplateFile
+		b, err := execLocalCommand(cpCmd)
 		if err != nil {
 			return fmt.Errorf("failed to copy template file: %v\nErrMessage:\n%s", err, string(b))
 		}
@@ -382,8 +382,8 @@ func (f *feature) deleteZoneSnapshotsAndRestore(location string) error {
 	for i := 0; i < int(f.zoneReplicaCount); i++ {
 		time.Sleep(10 * time.Second)
 
-		copyFile := exec.Command("cp", templateFile, updatedTemplateFile)
-		b, err := copyFile.CombinedOutput()
+		cpCmd := "cp " + templateFile + " " + updatedTemplateFile
+		b, err := execLocalCommand(cpCmd)
 		if err != nil {
 			return fmt.Errorf("failed to copy template file: %v\nErrMessage:\n%s", err, string(b))
 		}
@@ -438,10 +438,11 @@ func (f *feature) areAllRestoresRunning() error {
 		if runningCount != int(f.zoneReplicaCount) {
 			time.Sleep(10 * time.Second)
 			continue
-		} else {
-			complete = true
-			break
 		}
+
+		complete = true
+		break
+
 	}
 
 	if !complete {
@@ -451,12 +452,12 @@ func (f *feature) areAllRestoresRunning() error {
 	return nil
 }
 
-func replaceInFile(old, new, templateFile string) error {
-	cmdString := "s|" + old + "|" + new + "|g"
-	cmd := exec.Command("sed", "-i", cmdString, templateFile)
-	err := cmd.Run()
+func replaceInFile(oldString, newString, templateFile string) error {
+	cmdString := "s|" + oldString + "|" + newString + "|g"
+	replaceCmd := fmt.Sprintf("sed -i '%s' %s", cmdString, templateFile)
+	_, err := execLocalCommand(replaceCmd)
 	if err != nil {
-		return fmt.Errorf("failed to substitute %s with %s in file %s: %s", old, new, templateFile, err.Error())
+		return fmt.Errorf("failed to substitute %s with %s in file %s: %s", oldString, newString, templateFile, err.Error())
 	}
 	return nil
 }

--- a/test/e2e/e2e.go
+++ b/test/e2e/e2e.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"log"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -38,11 +39,12 @@ const (
 )
 
 type feature struct {
-	errs            []error
-	zoneNodeMapping map[string]string
-	zoneKey         string
-	supportedZones  []string
-	cordonedNode    string
+	errs             []error
+	zoneNodeMapping  map[string]string
+	zoneKey          string
+	supportedZones   []string
+	cordonedNode     string
+	zoneReplicaCount int32
 }
 
 func (f *feature) aVxFlexOSService() error {
@@ -214,12 +216,12 @@ func (f *feature) deleteZoneVolumes(fileLocation string) error {
 }
 
 func (f *feature) checkStatfulSetStatus() error {
-	log.Println("[checkStatfulSetStatus] checking statefulset status")
-
 	err := f.isStatefulSetReady()
 	if err != nil {
 		return err
 	}
+
+	log.Println("[checkStatfulSetStatus] Statefulset and zone pods are ready")
 
 	return nil
 }
@@ -244,6 +246,7 @@ func (f *feature) isStatefulSetReady() error {
 		// Everything should be ready.
 		if *sts.Spec.Replicas == sts.Status.ReadyReplicas {
 			ready = true
+			f.zoneReplicaCount = sts.Status.ReadyReplicas
 			break
 		}
 
@@ -339,6 +342,125 @@ func (f *feature) checkPodsForCordonRun() error {
 	return nil
 }
 
+func (f *feature) createZoneSnapshotsAndRestore(location string) error {
+	log.Println("[createZoneSnapshotsAndRestore] Creating snapshots and restores")
+	templateFile := "templates/" + location + "/snapshot.yaml"
+	updatedTemplateFile := "templates/" + location + "/snapshot-updated.yaml"
+
+	for i := 0; i < int(f.zoneReplicaCount); i++ {
+		time.Sleep(10 * time.Second)
+
+		copyFile := exec.Command("cp", templateFile, updatedTemplateFile)
+		b, err := copyFile.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to copy template file: %v\nErrMessage:\n%s", err, string(b))
+		}
+
+		// Update iteration and apply...
+		err = replaceInFile("ITERATION", strconv.Itoa(i), updatedTemplateFile)
+		if err != nil {
+			return err
+		}
+
+		createSnapshot := "kubectl apply -f " + updatedTemplateFile
+		_, err = execLocalCommand(createSnapshot)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Println("[createZoneSnapshotsAndRestore] Snapshots and restores created")
+
+	return nil
+}
+
+func (f *feature) deleteZoneSnapshotsAndRestore(location string) error {
+	log.Println("[createZoneSnapshotsAndRestore] Deleting restores and snapshots")
+	templateFile := "templates/" + location + "/snapshot.yaml"
+	updatedTemplateFile := "templates/" + location + "/snapshot-updated.yaml"
+
+	for i := 0; i < int(f.zoneReplicaCount); i++ {
+		time.Sleep(10 * time.Second)
+
+		copyFile := exec.Command("cp", templateFile, updatedTemplateFile)
+		b, err := copyFile.CombinedOutput()
+		if err != nil {
+			return fmt.Errorf("failed to copy template file: %v\nErrMessage:\n%s", err, string(b))
+		}
+
+		// Update iteration and apply...
+		err = replaceInFile("ITERATION", strconv.Itoa(i), updatedTemplateFile)
+		if err != nil {
+			return err
+		}
+
+		createSnapshot := "kubectl delete -f " + updatedTemplateFile
+		_, err = execLocalCommand(createSnapshot)
+		if err != nil {
+			return err
+		}
+	}
+
+	log.Println("[createZoneSnapshotsAndRestore] Snapshots and restores deleted")
+
+	return nil
+}
+
+func (f *feature) areAllRestoresRunning() error {
+	log.Println("[areAllRestoresRunning] Checking if all restores are running")
+
+	complete := false
+	attempts := 0
+	for attempts < 15 {
+		getZonePods := "kubectl get pods -n " + testNamespace + " -o jsonpath='{.items}'"
+		result, err := execLocalCommand(getZonePods)
+		if err != nil {
+			return err
+		}
+
+		pods := []v1Core.Pod{}
+		err = json.Unmarshal(result, &pods)
+		if err != nil {
+			return err
+		}
+
+		runningCount := 0
+		for _, pod := range pods {
+			if !strings.Contains(pod.ObjectMeta.Name, "snapshot-maz-restore") {
+				continue
+			}
+
+			if pod.Status.Phase == "Running" {
+				runningCount++
+			}
+		}
+
+		if runningCount != int(f.zoneReplicaCount) {
+			time.Sleep(10 * time.Second)
+			continue
+		} else {
+			complete = true
+			break
+		}
+	}
+
+	if !complete {
+		return fmt.Errorf("all restores not running, check pods status starting with snapshot-maz-restore and then try again")
+	}
+
+	return nil
+}
+
+func replaceInFile(old, new, templateFile string) error {
+	cmdString := "s|" + old + "|" + new + "|g"
+	cmd := exec.Command("sed", "-i", cmdString, templateFile)
+	err := cmd.Run()
+	if err != nil {
+		return fmt.Errorf("failed to substitute %s with %s in file %s: %s", old, new, templateFile, err.Error())
+	}
+	return nil
+}
+
 func execLocalCommand(command string) ([]byte, error) {
 	var buf bytes.Buffer
 	cmd := exec.Command("bash", "-c", command)
@@ -364,4 +486,7 @@ func InitializeScenario(s *godog.ScenarioContext) {
 	s.Step(`^check the statefulset for zones$`, f.checkStatfulSetStatus)
 	s.Step(`^cordon one node$`, f.cordonNode)
 	s.Step(`^ensure pods aren't scheduled incorrectly and still running$`, f.checkPodsForCordonRun)
+	s.Step(`^create snapshots for zone volumes and restore in "([^"]*)"$`, f.createZoneSnapshotsAndRestore)
+	s.Step(`^delete snapshots for zone volumes and restore in "([^"]*)"$`, f.deleteZoneSnapshotsAndRestore)
+	s.Step(`^all zone restores are running$`, f.areAllRestoresRunning)
 }

--- a/test/e2e/features/e2e.feature
+++ b/test/e2e/features/e2e.feature
@@ -29,3 +29,17 @@ Feature: VxFlex OS CSI interface
       | secret            | namespace  | location    |
       | "vxflexos-config" | "vxflexos" | "zone-wait" |
 
+  @zone
+  Scenario: Create zone voume and snapshots
+    Given a VxFlexOS service
+    And verify driver is configured and running correctly
+    And verify zone information from secret <secret> in namespace <namespace>
+    Then create zone volume and pod in <location>
+    And check the statefulset for zones
+    Then create snapshots for zone volumes and restore in <location>
+    And all zone restores are running
+    Then delete snapshots for zone volumes and restore in <location>
+    Then delete zone volume and pod in <location>
+    Examples:
+      | secret            | namespace  | location    |
+      | "vxflexos-config" | "vxflexos" | "zone-wait" |

--- a/test/e2e/features/e2e.feature
+++ b/test/e2e/features/e2e.feature
@@ -43,3 +43,18 @@ Feature: VxFlex OS CSI interface
     Examples:
       | secret            | namespace  | location    |
       | "vxflexos-config" | "vxflexos" | "zone-wait" |
+
+  @zone
+  Scenario: Create zone volume and clones
+    Given a VxFlexOS service
+    And verify driver is configured and running correctly
+    And verify zone information from secret <secret> in namespace <namespace>
+    Then create zone volume and pod in <location>
+    And check the statefulset for zones
+    Then create clones for zone volumes and restore in <location>
+    And all zone restores are running
+    Then delete clones for zone volumes and restore in <location>
+    Then delete zone volume and pod in <location>
+    Examples:
+      | secret            | namespace  | location    |
+      | "vxflexos-config" | "vxflexos" | "zone-wait" |

--- a/test/e2e/templates/zone-wait/clone.yaml
+++ b/test/e2e/templates/zone-wait/clone.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: clone-maz-pvcITERATION
+  namespace: vxflexos-test
+spec:
+  storageClassName: vxflexos-az-wait
+  dataSource:
+    name: multi-az-pvc-vxflextest-az-ITERATION
+    kind: PersistentVolumeClaim
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: clone-maz-restore-podITERATION
+  namespace: vxflexos-test
+spec:
+  containers:
+    - name: busybox
+      image: quay.io/quay/busybox:latest
+      command: ["/bin/sleep", "3600"]
+      volumeMounts:
+        - mountPath: "/data0"
+          name: multi-az-pvc
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "200m"
+          memory: "256Mi"
+  volumes:
+    - name: multi-az-pvc
+      persistentVolumeClaim:
+        claimName: clone-maz-pvcITERATION

--- a/test/e2e/templates/zone-wait/snapshot.yaml
+++ b/test/e2e/templates/zone-wait/snapshot.yaml
@@ -32,20 +32,20 @@ metadata:
   namespace: vxflexos-test
 spec:
   containers:
-  - name: busybox
-    image: quay.io/quay/busybox:latest
-    command: ["/bin/sleep", "3600"]
-    volumeMounts:
-    - mountPath: "/data0"
-      name: multi-az-pvc
-    resources:
-      requests:
-        cpu: "100m"
-        memory: "128Mi"
-      limits:
-        cpu: "200m"
-        memory: "256Mi"
+    - name: busybox
+      image: quay.io/quay/busybox:latest
+      command: ["/bin/sleep", "3600"]
+      volumeMounts:
+        - mountPath: "/data0"
+          name: multi-az-pvc
+      resources:
+        requests:
+          cpu: "100m"
+          memory: "128Mi"
+        limits:
+          cpu: "200m"
+          memory: "256Mi"
   volumes:
-  - name: multi-az-pvc
-    persistentVolumeClaim:
-      claimName: snapshot-maz-pvcITERATION
+    - name: multi-az-pvc
+      persistentVolumeClaim:
+        claimName: snapshot-maz-pvcITERATION

--- a/test/e2e/templates/zone-wait/snapshot.yaml
+++ b/test/e2e/templates/zone-wait/snapshot.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: snapshot-maz-ITERATION
+  namespace: vxflexos-test
+spec:
+  volumeSnapshotClassName: vxflexos-snapclass
+  source:
+    persistentVolumeClaimName: multi-az-pvc-vxflextest-az-ITERATION
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: snapshot-maz-pvcITERATION
+  namespace: vxflexos-test
+spec:
+  dataSource:
+    name: snapshot-maz-ITERATION
+    kind: VolumeSnapshot
+    apiGroup: snapshot.storage.k8s.io
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 8Gi
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: snapshot-maz-restore-podITERATION
+  namespace: vxflexos-test
+spec:
+  containers:
+  - name: busybox
+    image: quay.io/quay/busybox:latest
+    command: ["/bin/sleep", "3600"]
+    volumeMounts:
+    - mountPath: "/data0"
+      name: multi-az-pvc
+    resources:
+      requests:
+        cpu: "100m"
+        memory: "128Mi"
+      limits:
+        cpu: "200m"
+        memory: "256Mi"
+  volumes:
+  - name: multi-az-pvc
+    persistentVolumeClaim:
+      claimName: snapshot-maz-pvcITERATION


### PR DESCRIPTION
# Description
Add Snapshot and Clone support for the multi-available zone feature. This ensures that when a snapshot or clone is created from a volume that is zone capable, the snapshot/clone will be created within the same sone.

Prior to this, the node which the snapshot/clone could be created on might not be the same causing issues with Publishing on that node.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1612 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Add e2e tests to create snapshots from a zone volume.
```
$ make zone-e2e
go test -v -count=1 -timeout 1h -run '^TestZoneVolumes$' ./e2e
=== RUN   TestZoneVolumes
Feature: VxFlex OS CSI interface
  As a consumer of the CSI interface
  I want to run a system test
  So that I know the service functions correctly.
=== RUN   TestZoneVolumes/Create_zone_volume_through_k8s

  Scenario: Create zone volume through k8s                                    # features/e2e.feature:7
2024/12/05 14:03:23 [isEverythingWorking] Checking if everything is working...
2024/12/05 14:03:38 [createZoneVolumes] Created volumes and pods...
2024/12/05 14:05:22 [checkStatfulSetStatus] Statefulset and zone pods are ready
2024/12/05 14:05:33 [deleteZoneVolumes] Deleted volumes and pods...
    Given a VxFlexOS service                                                  # <autogenerated>:1 -> *feature
    And verify driver is configured and running correctly                     # <autogenerated>:1 -> *feature
    And verify zone information from secret <secret> in namespace <namespace> # <autogenerated>:1 -> *feature
    Then create zone volume and pod in <location>                             # <autogenerated>:1 -> *feature
    And check the statefulset for zones                                       # <autogenerated>:1 -> *feature
    Then delete zone volume and pod in <location>                             # <autogenerated>:1 -> *feature

    Examples:
      | secret            | namespace  | location    |
      | "vxflexos-config" | "vxflexos" | "zone-wait" |
=== RUN   TestZoneVolumes/Cordon_node_and_create_zone_volume_through_k8s

  Scenario: Cordon node and create zone volume through k8s                    # features/e2e.feature:19
2024/12/05 14:05:33 [isEverythingWorking] Checking if everything is working...
2024/12/05 14:05:36 [cordonNode] Cordoning node: worker-1-njo3bz3jjysjb
2024/12/05 14:05:37 [cordonNode] Cordoned node correctly
2024/12/05 14:05:48 [createZoneVolumes] Created volumes and pods...
2024/12/05 14:07:12 [checkStatfulSetStatus] Statefulset and zone pods are ready
2024/12/05 14:07:12 [checkPodsForCordonRun] checking pods status
2024/12/05 14:07:12 [getStatefulSetPods] Pods found:  7
2024/12/05 14:07:12 [checkPodsForCordonRun] Pods scheduled correctly, reseting node...
2024/12/05 14:07:24 [deleteZoneVolumes] Deleted volumes and pods...
    Given a VxFlexOS service                                                  # <autogenerated>:1 -> *feature
    And verify driver is configured and running correctly                     # <autogenerated>:1 -> *feature
    And verify zone information from secret <secret> in namespace <namespace> # <autogenerated>:1 -> *feature
    Then cordon one node                                                      # <autogenerated>:1 -> *feature
    Then create zone volume and pod in <location>                             # <autogenerated>:1 -> *feature
    And check the statefulset for zones                                       # <autogenerated>:1 -> *feature
    And ensure pods aren't scheduled incorrectly and still running            # <autogenerated>:1 -> *feature
    Then delete zone volume and pod in <location>                             # <autogenerated>:1 -> *feature

    Examples:
      | secret            | namespace  | location    |
      | "vxflexos-config" | "vxflexos" | "zone-wait" |
=== RUN   TestZoneVolumes/Create_zone_voume_and_snapshots

  Scenario: Create zone voume and snapshots                                   # features/e2e.feature:33
2024/12/05 14:07:24 [isEverythingWorking] Checking if everything is working...
2024/12/05 14:07:38 [createZoneVolumes] Created volumes and pods...
2024/12/05 14:09:33 [checkStatfulSetStatus] Statefulset and zone pods are ready
2024/12/05 14:09:33 [createZoneSnapshotsAndRestore] Creating snapshots and restores
2024/12/05 14:10:53 [createZoneSnapshotsAndRestore] Snapshots and restores created
2024/12/05 14:10:53 [areAllRestoresRunning] Checking if all restores are running
2024/12/05 14:11:04 [createZoneSnapshotsAndRestore] Deleting restores and snapshots
2024/12/05 14:15:55 [createZoneSnapshotsAndRestore] Snapshots and restores deleted
2024/12/05 14:16:06 [deleteZoneVolumes] Deleted volumes and pods...
    Given a VxFlexOS service                                                  # <autogenerated>:1 -> *feature
    And verify driver is configured and running correctly                     # <autogenerated>:1 -> *feature
    And verify zone information from secret <secret> in namespace <namespace> # <autogenerated>:1 -> *feature
    Then create zone volume and pod in <location>                             # <autogenerated>:1 -> *feature
    And check the statefulset for zones                                       # <autogenerated>:1 -> *feature
    Then create snapshots for zone volumes and restore in <location>          # <autogenerated>:1 -> *feature
    And all zone restores are running                                         # <autogenerated>:1 -> *feature
    Then delete snapshots for zone volumes and restore in <location>          # <autogenerated>:1 -> *feature
    Then delete zone volume and pod in <location>                             # <autogenerated>:1 -> *feature

    Examples:
      | secret            | namespace  | location    |
      | "vxflexos-config" | "vxflexos" | "zone-wait" |

3 scenarios (3 passed)
23 steps (23 passed)
12m43.019007047s
--- PASS: TestZoneVolumes (763.02s)
    --- PASS: TestZoneVolumes/Create_zone_volume_through_k8s (129.95s)
    --- PASS: TestZoneVolumes/Cordon_node_and_create_zone_volume_through_k8s (110.47s)
    --- PASS: TestZoneVolumes/Create_zone_voume_and_snapshots (522.59s)
PASS
ok      github.com/dell/csi-vxflexos/v2/test/e2e        763.066s
```
