### PR TITLE
Fix NodeGetVolumeStats Ephemeral Volume Handling 

### DIFF
--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1125,16 +1125,17 @@ Feature: VxFlex OS CSI interface
     And a correct NodeGetVolumeStats Response is returned
     
     Examples:
-      | error                    | errormsg                   | 
-      | "none"                   | "none"                     | 
-      | "BadVolIDError"          | "id must be a hexadecimal" | 
-      | "NoVolIDError"           | "no volume ID  provided"   |
-      | "BadMountPathError"      | "none"                     | 
-      | "NoMountPathError"       | "no volume Path provided"  | 
-      | "NoVolIDSDCError"        | "none"                     |  
-      | "GOFSMockGetMountsError" | "none"                     |
-      | "NoVolError"             | "none"                     |
-      | "NoSysNameError"         | "systemID is not found"    |
+      | error                    | errormsg                          | 
+      | "none"                   | "none"                            | 
+      | "BadVolIDError"          | "id must be a hexadecimal"        | 
+      | "NoVolIDError"           | "no volume ID  provided"          |
+      | "BadMountPathError"      | "none"                            | 
+      | "NoMountPathError"       | "no volume Path provided"         | 
+      | "NoVolIDSDCError"        | "none"                            |   
+      | "GOFSMockGetMountsError" | "none"                            |
+      | "NoVolError"             | "none"                            |
+      | "NoSysNameError"         | "systemID is not found"           |
+      | "WrongSystemError"       | "is not configured in the driver" | 
 
   Scenario: Call getSystemNameMatchingError, should get error in log but no error returned
     Given a VxFlexOS service

--- a/service/node.go
+++ b/service/node.go
@@ -830,6 +830,12 @@ func (s *service) NodeGetVolumeStats(ctx context.Context, req *csi.NodeGetVolume
 			"systemID is not found in the request and there is no default system")
 	}
 
+	// make sure systemID we get is managed by the driver
+	if err := s.requireProbe(ctx, systemID); err != nil {
+		Log.Infof("System: %s is not managed by driver; volume stats will not be collected", systemID)
+		return nil, err
+	}
+
 	_, err := s.getSDCMappedVol(volID, systemID, 30)
 	if err != nil {
 		// volume not known to SDC, next check if it exists at all

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3348,6 +3348,9 @@ func (f *feature) iCallNodeGetVolumeStats() error {
 	if stepHandlersErrors.NoSysNameError {
 		f.service.opts.defaultSystemID = ""
 	}
+	if stepHandlersErrors.WrongSystemError {
+		VolumeID = "wrongsystem-435645643"
+	}
 
 	req := &csi.NodeGetVolumeStatsRequest{VolumeId: VolumeID, VolumePath: VolumePath}
 
@@ -3357,7 +3360,7 @@ func (f *feature) iCallNodeGetVolumeStats() error {
 }
 
 func (f *feature) aCorrectNodeGetVolumeStatsResponse() error {
-	if stepHandlersErrors.NoVolIDError || stepHandlersErrors.NoMountPathError || stepHandlersErrors.BadVolIDError || stepHandlersErrors.NoSysNameError {
+	if stepHandlersErrors.NoVolIDError || stepHandlersErrors.NoMountPathError || stepHandlersErrors.BadVolIDError || stepHandlersErrors.NoSysNameError || stepHandlersErrors.WrongSystemError {
 		// errors and no responses should be returned in these instances
 		if f.nodeGetVolumeStatsResponse == nil {
 			fmt.Printf("Response check passed\n")


### PR DESCRIPTION
# Description
An issue was found that when NodeGetVolumeStats was called on an ephemeral volume, the driver could crash. 
This exposed an overall gap in NodeGetVolumeStats because we never checked if the system was configured with the driver before, which can lead to a panic in cases where it is not. 

Now it will return an error instead of panic
```
time="2024-12-13T19:57:42Z" level=info msg="/csi.v1.Node/NodeGetVolumeStats: REQ 0072: VolumeId=csi-acb496e5c64e89255148da2c30b1a43815ff992e6fa970643e17f8b01b96fe32, VolumePath=/var/lib/kubelet/pods/1a14e1a4-4878-43fd-95be-31812d9e201d/volumes/kubernetes.io~csi/ephemeral-vol/mount, XXX_NoUnkeyedLiteral={}, XXX_sizecache=0"
time="2024-12-13T19:57:42Z" level=debug msg="probing system csi automatically"
time="2024-12-13T19:57:42Z" level=info msg="System: csi is not managed by driver; volume stats will not be collected"
time="2024-12-13T19:57:42Z" level=info msg="/csi.v1.Node/NodeGetVolumeStats: REP 0072: rpc error: code = InvalidArgument desc = system csi is not configured in the driver"

```

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
