### PR TITLE
Get csm-base-image instead of building it.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,7 +1,7 @@
 name: Release CSI-Powerflex
 # Invocable as a reusable workflow
 # Can be manually triggered
-on: # yamllint disable-line rule:truthy
+on:  # yamllint disable-line rule:truthy
   workflow_call:
   workflow_dispatch:
     inputs:

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,11 @@ build: dependencies
 
 # Generates the docker container (but does not push)
 docker: dependencies
-	make -f docker.mk build-base-image docker
+	make -f docker.mk docker
 
 # Generates the docker container with no cache (but does not push)
 docker-no-cache: dependencies
-	make -f docker.mk build-base-image docker-no-cache
+	make -f docker.mk docker-no-cache
 
 # Pushes container to the repository
 push: docker

--- a/docker.mk
+++ b/docker.mk
@@ -19,7 +19,7 @@ docker: download-csm-common
 	$(eval include csm-common.mk)
 	@echo "Base Images is set to: $(BASEIMAGE)"
 	@echo "Building: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
-	$(BUILDER) build $(NOCACHE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --target $(BUILDSTAGE) --build-arg GOPROXY --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)  .
+	$(BUILDER) build --pull $(NOCACHE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --target $(BUILDSTAGE) --build-arg GOPROXY --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)  .
 
 docker-no-cache: download-csm-common
 	@echo "Building with --no-cache ..."

--- a/docker.mk
+++ b/docker.mk
@@ -15,12 +15,13 @@ IMAGETAG="v$(MAJOR).$(MINOR).$(PATCH)$(RELNOTE)"
 endif
 
 
-docker:
+docker: download-csm-common
+	$(eval include csm-common.mk)
 	@echo "Base Images is set to: $(BASEIMAGE)"
 	@echo "Building: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
-	$(BUILDER) build $(NOCACHE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --target $(BUILDSTAGE) --build-arg GOPROXY --build-arg BASEIMAGE=$(BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)  .
+	$(BUILDER) build $(NOCACHE) -t "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)" --target $(BUILDSTAGE) --build-arg GOPROXY --build-arg BASEIMAGE=$(CSM_BASEIMAGE) --build-arg GOIMAGE=$(DEFAULT_GOIMAGE)  .
 
-docker-no-cache:
+docker-no-cache: download-csm-common
 	@echo "Building with --no-cache ..."
 	@make docker NOCACHE=--no-cache
 
@@ -28,12 +29,6 @@ push:
 	@echo "Pushing: $(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 	$(BUILDER) push "$(REGISTRY)/$(IMAGENAME):$(IMAGETAG)"
 
-build-base-image: download-csm-common
-	$(eval include csm-common.mk)
-	@echo "Building base image from $(DEFAULT_BASEIMAGE) and loading dependencies..."
-	./scripts/build_ubi_micro.sh $(DEFAULT_BASEIMAGE)
-	@echo "Base image build: SUCCESS"
-	$(eval BASEIMAGE=localhost/csipowerflex-ubimicro:latest)
 
 download-csm-common:
 	curl -O -L https://raw.githubusercontent.com/dell/csm/main/config/csm-common.mk


### PR DESCRIPTION
# Description
Use the common CSM base image for image builds. The benefit is that it will now be possible to build images on non RHEL VMs and as a non root user.

# GitHub Issues

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1691 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Unit tests
- [x] Built Images
- [x] Run cert-csi on image
