### PR TITLE
Update updateConfigMap: Prepare driver configmap name based on release name

### DIFF
--- a/service/service.go
+++ b/service/service.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+// Copyright © 2019-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -3334,6 +3334,7 @@ func (f *feature) iCallBeforeServe() error {
 		K8sClientset = nil
 	}
 	os.Setenv(gocsi.EnvVarMode, "node")
+	defer os.Unsetenv(gocsi.EnvVarMode)
 	f.err = f.service.BeforeServe(ctx, nil, listener)
 	listener.Close()
 	return nil

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dell/dell-csi-extensions/podmon"
 	"github.com/dell/dell-csi-extensions/replication"
 	volGroupSnap "github.com/dell/dell-csi-extensions/volumeGroupSnapshot"
+	"github.com/dell/gocsi"
 	"github.com/dell/gofsutil"
 	"github.com/dell/goscaleio"
 	types "github.com/dell/goscaleio/types/v1"
@@ -3294,6 +3295,7 @@ func (f *feature) theConfigMapIsUpdated() error {
 
 	s := &service{}
 	s.opts.KubeNodeName = "worker1"
+	os.Setenv("RELEASE_NAME", "vxflexos")
 	s.updateConfigMap(GetIPAddressByInterface, "driver-config-params.yaml")
 	return nil
 }
@@ -3331,6 +3333,7 @@ func (f *feature) iCallBeforeServe() error {
 	if stepHandlersErrors.UpdateConfigK8sClientError {
 		K8sClientset = nil
 	}
+	os.Setenv(gocsi.EnvVarMode, "node")
 	f.err = f.service.BeforeServe(ctx, nil, listener)
 	listener.Close()
 	return nil


### PR DESCRIPTION
# Description
This PR update updateConfigMap to prepare the driver configmap name dynamically based on the release name provided.
RELEASE_NAME env is added in the driver container node template in helm-charts & csm-operator.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1774 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- Installed the driver with dynamic release name, driver pods coming up with the new release name given
`./csi-install.sh --namespace vxflexos --values  values.yaml --release=pflex --skip-verify-node`
![image](https://github.com/user-attachments/assets/2c183ec6-50a3-4db4-b607-46d06eb71182)

- Verified the configmap is created with the new release name
![image](https://github.com/user-attachments/assets/43219290-7681-41e7-a16c-a272164d1664)

- Verified configmap getting updated successfully and not seeing the error : `Failed to get configmap`
![image](https://github.com/user-attachments/assets/5c74c2b6-597d-4d05-b9c7-44ef8f574a48)

- Able to see env `RELEASE_NAME` getting added in the driver node pod
![image](https://github.com/user-attachments/assets/b73b6707-fef9-441c-89a7-ba4d2f24e858)
