### PR TITLE
Add condition for node-expansion 

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -3372,11 +3372,7 @@ func (s *service) ControllerExpandVolume(ctx context.Context, req *csi.Controlle
 		return &csi.ControllerExpandVolumeResponse{}, nil
 	}
 
-	nodeExpansionRequired := false
-	if len(vol.MappedSdcInfo) > 0 {
-		// Volume is in use
-		nodeExpansionRequired = true
-	}
+	nodeExpansionRequired := len(vol.MappedSdcInfo) > 0
 
 	if requestedSize == allocatedSize {
 		Log.Infof("Idempotent call detected for volume (%s) with requested size (%d) SizeInKb and allocated size (%d) SizeInKb",


### PR DESCRIPTION
# Description
Node expansion is failing due to csi-resizer-1.13.1 not being backward compatibility.
Adding a function in controller expand volume to check if the volumes are mapped and then setting the flag if the expansion has to be performed or not.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [ ] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B
