### PR TITLE
Add documentation for OCP certification tests

### DIFF
--- a/test/certification/README.md
+++ b/test/certification/README.md
@@ -1,0 +1,47 @@
+# OpenShift CSI certification tests
+
+This directory contains information for running the RedHat OpenShift certification tests.
+
+## Requirements
+
+* An OpenShift cluster
+  * The number of pods that can be scheduled per node must be configured to 350 or higher. OpenShift sets the limit to 250, but the LUN Stress test will attempt to schedule 260 pods on a single node.
+* The driver already installed with controller pods scheduled to master nodes.
+* A container runner, e.g. docker or podman.
+* A Kubeconfig from the target cluster named `kubeconfig.yaml`.
+* A [storage class](https://github.com/dell/csi-powerflex/tree/main/samples/storageclass) named `storageclass.yaml`
+* A [volume snapshot class](https://github.com/dell/csi-powerflex/tree/main/samples/volumesnapshotclass) named `snapclass.yaml`
+
+## Running the tests
+1. Ensure all YAML manifests are in the same directory.
+2. Prepare the following files:
+    - `kubeconfig.yaml`
+    - `upstream-manifest.yaml`
+    - `storageclass.yaml`
+    - `snapclass.yaml`
+3. Create and prepare `pull-secret.json` with credentials to access the Red Hat catalog.
+4. Pull the tester container image that corresponds to your OpenShift cluster version:
+    ```bash
+    $ podman pull --authfile pull-secret.json $(oc adm release info --image-for=tests)
+    ```
+    **Note**: There may be a newer [OCP End to End image](https://catalog.redhat.com/search?gs&q=OpenShift%20End-to-End%20Tests) available.
+6. The `openshift-tests` binary in the container image can be found at `/usr/bin/openshift-tests`.
+   - `/usr/bin/openshift-tests run openshift/csi --dry-run` will list the names of tests that will run.
+   - `/usr/bin/openshift-tests run openshift/csi` will run all certification tests.
+   - `/usr/bin/openshift-tests run openshift/csi --run=<regexp>` will run a set of monitors and specific tests.
+   - `/usr/bin/openshift-tests run openshift/csi run-test <test name>` will run a single test, without any monitors.
+7. Prepare `run.sh` for the test(s) you want to execute.
+
+    Example for running the LUN Stress test:
+    ```bash
+    $ podman run -v $DATA:/data:z --rm -it $TESTIMAGE sh -c "KUBECONFIG=/data/kubeconfig.yaml TEST_CSI_DRIVER_FILES=/data/manifest.yaml TEST_OCP_CSI_DRIVER_FILES=/data/ocp-manifest.yaml /usr/bin/openshift-tests run-test 'External Storage [Driver: csi-vxflexos.dellemc.com] [Testpattern: Dynamic PV (filesystem volmode)] OpenShift CSI extended - SCSI LUN Overflow should use many PVs on a single node [Serial][Timeout:40m]' |& tee test.log
+    ```
+8. Run inside of the openshift-tests container image:
+    ```bash
+    $ sh run.sh
+    ```
+
+#### Tips:
+- More usage on the `openshift-tests` container image can be found [here](https://github.com/openshift/origin/blob/main/test/extended/storage/csi/README.md#usage).
+- By default, `X_CSI_MAX_VOLUMES_PER_NODE` is set to 0. Set this value to 350 or higher in the driver daemonset to guarantee the number of volumes that can be published by the controller to the node.
+- If mounting errors occur, such as `mount(2) system call failed: Structure needs cleaning`, it may indicate too many files open on the worker node. Diagnose the issue by checking kernel logs or running the lsof command. Rebooting the worker nodes in the cluster will also decrease the number of open files.

--- a/test/certification/ocp-manifest.yaml
+++ b/test/certification/ocp-manifest.yaml
@@ -1,0 +1,4 @@
+Driver: csi-vxflexos.dellemc.com
+LUNStressTest:
+  PodsTotal: 260
+  Timeout: "40m"

--- a/test/certification/run.sh
+++ b/test/certification/run.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+trap "echo Can't stop now!" INT
+
+TIMESTAMP=$(date +%Y%m%d%H%M%S)
+DATA=/home/LUNStress/$TIMESTAMP
+TESTIMAGE=$(oc adm release info --image-for=tests)
+
+mkdir $DATA || exit 1
+
+for i in manifest.yaml ocp-manifest.yaml kubeconfig.yaml storageclass.yaml snapclass.yaml; do
+    cp $i $DATA/$i
+done
+
+podman run -v $DATA:/data:z --rm -it $TESTIMAGE sh -c "KUBECONFIG=/data/kubeconfig.yaml TEST_CSI_DRIVER_FILES=/data/manifest.yaml TEST_OCP_CSI_DRIVER_FILES=/data/ocp-manifest.yaml /usr/bin/openshift-tests run openshift/csi --dry-run" |& tee test.log
+
+tar -C $DATA -czf $TIMESTAMP/results-$TIMESTAMP.tar.gz results *yaml

--- a/test/certification/upstream-manifest.yaml
+++ b/test/certification/upstream-manifest.yaml
@@ -1,0 +1,81 @@
+ShortName: powerflex
+StorageClass:
+  # Load a StorageClass from the given file. This file must be in the same directory as this one
+  FromFile: storageclass.yaml
+
+SnapshotClass:
+  FromName: true
+  FromFile: snapclass.yaml
+
+DriverInfo:
+  # Internal name of the driver, this is used as a display name in the test case and test objects
+  Name: csi-vxflexos.dellemc.com
+
+  # The range of disk size supported by this driver
+  SupportedSizeRange:
+    Min: 8Gi
+    Max: 16Ti
+
+  # Map of strings for supported FS types
+  SupportedFsType:
+    ext4: {}
+    xfs: {}
+
+  # Map of strings for supported mount options
+  SupportedMountOption:
+    dirsync: {}
+
+  # Optional list of topology keys that the driver supports
+  TopologyKeys: ["csi-vxflexos.dellemc.com/[INSERT SYSTEM ID]"]
+  # Optional number of allowed topologies that the driver requires. Only relevant if TopologyKeys is set
+  NumAllowedTopologies: 1
+
+  # Map of strings for required mount options
+  # RequiredMountOption:
+
+  # Optional list of access modes required for provisiong. Default is RWO
+  RequiredAccessModes:
+    - ReadWriteOnce
+
+  # Map that represents the capabilities the driver supports
+  Capabilities:
+    # Data is persistest accross pod restarts
+    persistence: true
+
+    # Volume ownership via fsGroup
+    fsGroup: true
+
+    # Raw block mode
+    block: true
+
+    # Exec a file in the volume
+    exec: true
+
+    # Support for volume limits
+    volumeLimits: false
+
+    # Support for volume expansion in controllers
+    controllerExpansion: true
+
+    # Support for volume expansion in nodes
+    nodeExpansion: true
+
+    # Support volume that an run on single node only (like hostpath)
+    singleNodeVolume: false
+
+    # Support ReadWriteMany access modes
+    RWX: false
+
+    # Support topology
+    topology: true
+
+    # Support populate data from snapshot
+    snapshotDataSource: true
+
+    # Support populated data from PVC
+    pvcDataSource: true
+
+  StressTestOptions:
+    NumPods: 10
+    NumRestarts: 20
+    NumSnapshots: 10


### PR DESCRIPTION
# Description
This PR adds documentation and necessary files for running the ocp certification tests for the driver.
# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
|https://github.com/dell/csm/issues/1811 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [ ] I have verified that new and existing unit tests pass locally with my changes
- [ ] I have not allowed coverage numbers to degenerate
- [ ] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] These files were tested on an ocp cluster
```
 I0403 16:48:08.577374 1 scsi_overflow.go:196] Waiting for 260 pods to complete, 249 done
  I0403 16:48:18.569178 1 scsi_overflow.go:101] All pods completed, cleaning up
  I0403 16:48:42.105885 1 scsi_overflow.go:85] Cleaning up StorageClass e2e-storage-lun-overflow-8332-e2e-scvh29x
    STEP: Destroying namespace "e2e-storage-lun-overflow-8332" for this suite. @ 04/03/25 16:48:42.153
  • [917.474 seconds]
  ------------------------------

  Ran 1 of 1 Specs in 917.474 seconds
  SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
```
