### PR TITLE
Update NodeExpandVolume to conform to CSI 1.6

### DIFF
--- a/service/node.go
+++ b/service/node.go
@@ -987,7 +987,7 @@ func (s *service) NodeExpandVolume(ctx context.Context, req *csi.NodeExpandVolum
 	// If not a directory, assume it's a raw block device mount and return ok.
 	volumePathInfo, err := os.Lstat(volumePath)
 	if err != nil {
-		return nil, status.Error(codes.InvalidArgument, "Could not stat volume path: "+volumePath)
+		return nil, status.Error(codes.NotFound, "Could not stat volume path: "+volumePath)
 	}
 	if !volumePathInfo.Mode().IsDir() {
 		Log.Infof("Volume path %s is not a directory- assuming a raw block device mount", volumePath)


### PR DESCRIPTION
# Description
Returns appropriate status code in _NodeExpandVolume_ call.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

- [x] csi-sanity tests for _NodeExpandVolume_
```
[root@worker-1-gMLffggcEYiL6 sanity]# sh run.sh
Running Suite: CSI Driver Test Suite - /home/santhosh/csm/csi-powerflex/test/sanity
===================================================================================
Random Seed: 1748882737

Will run 4 of 78 specs
SSSSSSSSSS
------------------------------
P [PENDING]
Controller Service [Controller Server] ListVolumes pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted
/home/santhosh/csi-test/pkg/sanity/controller.go:268
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
Node Service NodeExpandVolume
  should fail when no volume id is provided
  /home/santhosh/csi-test/pkg/sanity/node.go:740
STEP: connecting to CSI driver 06/02/25 11:45:37.349
STEP: creating mount and staging directories 06/02/25 11:45:37.35
------------------------------
• [0.008 seconds]
Node Service
/home/santhosh/csi-test/pkg/sanity/tests.go:45
  NodeExpandVolume
  /home/santhosh/csi-test/pkg/sanity/node.go:732
    should fail when no volume id is provided
    /home/santhosh/csi-test/pkg/sanity/node.go:740

  Begin Captured GinkgoWriter Output >>
    STEP: connecting to CSI driver 06/02/25 11:45:37.349
    STEP: creating mount and staging directories 06/02/25 11:45:37.35
  << End Captured GinkgoWriter Output
------------------------------
Node Service NodeExpandVolume
  should fail when no volume path is provided
  /home/santhosh/csi-test/pkg/sanity/node.go:755
STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:37.358
STEP: creating mount and staging directories 06/02/25 11:45:37.358
STEP: creating a single node writer volume for expansion 06/02/25 11:45:37.36
------------------------------
• [SLOW TEST] [5.210 seconds]
Node Service
/home/santhosh/csi-test/pkg/sanity/tests.go:45
  NodeExpandVolume
  /home/santhosh/csi-test/pkg/sanity/node.go:732
    should fail when no volume path is provided
    /home/santhosh/csi-test/pkg/sanity/node.go:755

  Begin Captured GinkgoWriter Output >>
    STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:37.358
    STEP: creating mount and staging directories 06/02/25 11:45:37.358
    STEP: creating a single node writer volume for expansion 06/02/25 11:45:37.36
  << End Captured GinkgoWriter Output
------------------------------
Node Service NodeExpandVolume
  should fail when volume is not found
  /home/santhosh/csi-test/pkg/sanity/node.go:774
STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:42.567
STEP: creating mount and staging directories 06/02/25 11:45:42.567
------------------------------
• [0.016 seconds]
Node Service
/home/santhosh/csi-test/pkg/sanity/tests.go:45
  NodeExpandVolume
  /home/santhosh/csi-test/pkg/sanity/node.go:732
    should fail when volume is not found
    /home/santhosh/csi-test/pkg/sanity/node.go:774

  Begin Captured GinkgoWriter Output >>
    STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:42.567
    STEP: creating mount and staging directories 06/02/25 11:45:42.567
  << End Captured GinkgoWriter Output
------------------------------
Node Service NodeExpandVolume
  should work if node-expand is called after node-publish
  /home/santhosh/csi-test/pkg/sanity/node.go:789
STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:42.584
STEP: creating mount and staging directories 06/02/25 11:45:42.584
STEP: creating a single node writer volume for expansion 06/02/25 11:45:42.587
STEP: controller expanding the volume 06/02/25 11:45:42.707
STEP: getting a node id 06/02/25 11:45:42.737
STEP: controller publishing volume 06/02/25 11:45:42.788
STEP: publishing the volume on a node 06/02/25 11:45:42.894
STEP: expanding the volume on a node 06/02/25 11:45:45.734
------------------------------
• [3.311 seconds]
Node Service
/home/santhosh/csi-test/pkg/sanity/tests.go:45
  NodeExpandVolume
  /home/santhosh/csi-test/pkg/sanity/node.go:732
    should work if node-expand is called after node-publish
    /home/santhosh/csi-test/pkg/sanity/node.go:789

  Begin Captured GinkgoWriter Output >>
    STEP: reusing connection to CSI driver at ./unix_sock 06/02/25 11:45:42.584
    STEP: creating mount and staging directories 06/02/25 11:45:42.584
    STEP: creating a single node writer volume for expansion 06/02/25 11:45:42.587
    STEP: controller expanding the volume 06/02/25 11:45:42.707
    STEP: getting a node id 06/02/25 11:45:42.737
    STEP: controller publishing volume 06/02/25 11:45:42.788
    STEP: publishing the volume on a node 06/02/25 11:45:42.894
    STEP: expanding the volume on a node 06/02/25 11:45:45.734
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSSSSSSSSSS

Ran 4 of 78 Specs in 8.550 seconds
SUCCESS! -- 4 Passed | 0 Failed | 1 Pending | 73 Skipped
```

- [x] cert-csi test suites
```
[root@master-1-gMLffggcEYiL6 cert-csi]# ./cert-csi certify --cert-config powerflex-config.yaml --vsc vxflexos-snapclass
[2025-06-02 12:28:57]  INFO Starting cert-csi; ver. 1.8.0
......
[2025-06-02 12:28:57]  INFO Suites to run with vxflexos storage class:
[2025-06-02 12:28:57]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
[2025-06-02 12:28:57]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
[2025-06-02 12:28:57]  INFO 3. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
[2025-06-02 12:28:57]  INFO 4. VolumeExpansionSuite {pods: 1, volumes: 1, size: 8Gi, expSize: 16Gi, block: false}
[2025-06-02 12:28:57]  INFO 5. VolumeExpansionSuite {pods: 1, volumes: 1, size: 8Gi, expSize: 16Gi, block: true}
[2025-06-02 12:28:57]  INFO 6. SnapSuite {snapshots: 3, volumeSize; 8Gi}
[2025-06-02 12:28:57]  INFO 7. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
[2025-06-02 12:28:57]  INFO 8. MultiAttachSuite {pods: 5, rawBlock: true, size: 8Gi, accMode: ReadWriteMany}
[2025-06-02 12:28:57]  INFO 9. EphemeralVolumeSuite {driver: csi-vxflexos.dellemc.com, podNumber: 2, volAttributes: map[size:8Gi storagepool:<SP1> systemID:<ID>volumeName:my-ephemeral-vol]}
Does it look OK? (Y)es/(n)o
-> Y
....
[2025-06-02 12:32:01]  INFO Avg time of a run:   85.11s
[2025-06-02 12:32:01]  INFO Avg time of a del:   23.65s
[2025-06-02 12:32:01]  INFO Avg time of all:     111.64s
[2025-06-02 12:32:01]  INFO During this run 100.0% of suites succeeded
```