### PR TITLE
Update DeleteVolume to conform to CSI 1.6

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -1,4 +1,4 @@
-// Copyright © 2019-2024 Dell Inc. or its subsidiaries. All Rights Reserved.
+// Copyright © 2019-2025 Dell Inc. or its subsidiaries. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -1483,7 +1483,8 @@ func (s *service) ControllerPublishVolume(
 	volID := getVolumeIDFromCsiVolumeID(csiVolID)
 	vol, err := s.getVolByID(volID, systemID)
 	if err != nil {
-		if strings.EqualFold(err.Error(), sioGatewayVolumeNotFound) || strings.Contains(err.Error(), "must be a hexadecimal number") {
+		if strings.EqualFold(err.Error(), sioGatewayVolumeNotFound) || strings.Contains(err.Error(), "must be a hexadecimal number") ||
+			strings.Contains(err.Error(), "Invalid volume") {
 			return nil, status.Error(codes.NotFound,
 				"volume not found")
 		}
@@ -1879,7 +1880,8 @@ func (s *service) ValidateVolumeCapabilities(
 	volID := getVolumeIDFromCsiVolumeID(csiVolID)
 	_, err = s.getVolByID(volID, systemID)
 	if err != nil {
-		if strings.EqualFold(err.Error(), sioGatewayVolumeNotFound) || strings.Contains(err.Error(), "must be a hexadecimal number") {
+		if strings.EqualFold(err.Error(), sioGatewayVolumeNotFound) || strings.Contains(err.Error(), "must be a hexadecimal number") ||
+			strings.Contains(err.Error(), "Invalid volume") {
 			return nil, status.Error(codes.NotFound,
 				"volume not found")
 		}

--- a/service/service.go
+++ b/service/service.go
@@ -1169,14 +1169,15 @@ func (s *service) getFileInterface(systemID string, fs *siotypes.FileSystem, cli
 
 // getSystemIDFromCsiVolumeId returns PowerFlex volume ID from CSI volume ID
 func (s *service) getSystemIDFromCsiVolumeID(csiVolID string) string {
-	containsHyphen := strings.Contains(csiVolID, "/")
-	if containsHyphen {
+	containsSlash := strings.Contains(csiVolID, "/")
+	if containsSlash {
 		i := strings.LastIndex(csiVolID, "/")
 		if i == -1 {
 			return ""
 		}
 		tokens := strings.Split(csiVolID, "/")
-		if len(tokens) > 1 {
+		// expected format: sysId/fsId
+		if len(tokens) == 2 {
 			sys := csiVolID[:i]
 			if id, ok := s.connectedSystemNameToID[sys]; ok {
 				return id
@@ -1189,7 +1190,8 @@ func (s *service) getSystemIDFromCsiVolumeID(csiVolID string) string {
 			return ""
 		}
 		tokens := strings.Split(csiVolID, "-")
-		if len(tokens) > 1 {
+		// expected format: sysId-volId
+		if len(tokens) == 2 {
 			sys := csiVolID[:i]
 			if id, ok := s.connectedSystemNameToID[sys]; ok {
 				return id


### PR DESCRIPTION
# Description
Changes for DeleteVolume to be CSI spec compliant, to handle invalid volume id.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1896 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?

- [x] csi-sanity test for DeleteVolume that was failing.
```
Running Suite: CSI Driver Test Suite - /home/santhosh/csm/csi-powerflex/test/sanity
===================================================================================
Random Seed: 1749662057

Will run 1 of 78 specs
SSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSSS
------------------------------
P [PENDING]
Controller Service [Controller Server] ListVolumes pagination should detect volumes added between pages and accept tokens when the last volume from a page is deleted
/home/santhosh/csi-test/pkg/sanity/controller.go:268
------------------------------
SSSSSSSSSSSS
------------------------------
Controller Service [Controller Server] DeleteVolume
  should succeed when an invalid volume id is used
  /home/santhosh/csi-test/pkg/sanity/controller.go:686
STEP: connecting to CSI driver 06/11/25 12:14:17.169
STEP: creating mount and staging directories 06/11/25 12:14:17.17
------------------------------
• [0.025 seconds]
Controller Service [Controller Server]
/home/santhosh/csi-test/pkg/sanity/tests.go:45
  DeleteVolume
  /home/santhosh/csi-test/pkg/sanity/controller.go:664
    should succeed when an invalid volume id is used
    /home/santhosh/csi-test/pkg/sanity/controller.go:686

  Begin Captured GinkgoWriter Output >>
    STEP: connecting to CSI driver 06/11/25 12:14:17.169
    STEP: creating mount and staging directories 06/11/25 12:14:17.17
  << End Captured GinkgoWriter Output
------------------------------
SSSSSSSSSSSSSSSSSSSSSSSS

Ran 1 of 78 Specs in 0.027 seconds
SUCCESS! -- 1 Passed | 0 Failed | 1 Pending | 76 Skipped```
```

- [x] All csi-sanity tests have passed now.
```
Ran 66 of 78 Specs in 199.284 seconds
SUCCESS! -- 66 Passed | 0 Failed | 1 Pending | 11 Skipped

```
- [x] cert-csi test suites

```
[root@master-1-gMLffggcEYiL6 cert-csi]# ./cert-csi certify --cert-config powerflex-config.yaml --vsc vxflexos-snapclass
[2025-06-11 12:14:50]  INFO Starting cert-csi; ver. 1.8.0
.....
[2025-06-11 12:14:50]  INFO Suites to run with vxflexos storage class:
[2025-06-11 12:14:50]  INFO 1. VolumeIoSuite {volumes: 2, volumeSize: 8Gi chains: 2-2}
[2025-06-11 12:14:50]  INFO 2. ScalingSuite {replicas: 2, volumes: 5, volumeSize: 8Gi}
[2025-06-11 12:14:50]  INFO 3. CloneVolumeSuite {pods: 2, volumes: 1, volumeSize: 8Gi}
[2025-06-11 12:14:50]  INFO 4. VolumeExpansionSuite {pods: 1, volumes: 1, size: 8Gi, expSize: 16Gi, block: false}
[2025-06-11 12:14:50]  INFO 5. VolumeExpansionSuite {pods: 1, volumes: 1, size: 8Gi, expSize: 16Gi, block: true}
[2025-06-11 12:14:50]  INFO 6. SnapSuite {snapshots: 3, volumeSize; 8Gi}
[2025-06-11 12:14:50]  INFO 7. ReplicationSuite {pods: 2, volumes: 5, volumeSize: 8Gi}
[2025-06-11 12:14:50]  INFO 8. MultiAttachSuite {pods: 5, rawBlock: true, size: 8Gi, accMode: ReadWriteMany}
[2025-06-11 12:14:50]  INFO 9. EphemeralVolumeSuite {driver: csi-vxflexos.dellemc.com, podNumber: 2, volAttributes: map[size:8Gi storagepool:<SP1> systemID:<ID> volumeName:my-ephemeral-vol]}
Does it look OK? (Y)es/(n)o
...
[2025-06-11 12:18:10]  INFO Avg time of a run:   92.16s
[2025-06-11 12:18:10]  INFO Avg time of a del:   26.79s
[2025-06-11 12:18:10]  INFO Avg time of all:     121.78s
[2025-06-11 12:18:10]  INFO During this run 100.0% of suites succeeded
```