### PR TITLE
Configurable Probe Timeout

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -137,7 +137,7 @@ const (
 
 	DriverConfigParamsYaml = "driver-config-params.yaml"
 
-	DefaultAPITimeout = 5 * time.Second
+	DefaultAPITimeout = 10 * time.Second
 )
 
 // Extra metadata field names for propagating to goscaleio and beyond.
@@ -2630,7 +2630,7 @@ func (s *service) systemProbeAll(ctx context.Context) error {
 		Log.Infof("probing zoneLabel '%s', zone value: '%s'", s.opts.zoneLabelKey, zoneName)
 	}
 
-	newCtx, cancel := createProbeContextWithDeadline(ctx)
+	newCtx, cancel := s.createProbeContextWithDeadline(ctx)
 	defer cancel()
 
 	for _, array := range s.opts.arrays {
@@ -3760,12 +3760,12 @@ func (s *service) verifySystem(systemID string) (*goscaleio.Client, error) {
 	return adminClient, nil
 }
 
-func createProbeContextWithDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
-	defaultProbeDeadline := time.Now().Add(DefaultAPITimeout)
+func (s *service) createProbeContextWithDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	defaultProbeDeadline := time.Now().Add(s.opts.probeTimeout)
 	probeDeadline, ok := ctx.Deadline()
 	if !ok {
 		Log.Println("Probe deadline not in context, using default")
-		probeDeadline = time.Now().Add(DefaultAPITimeout)
+		probeDeadline = time.Now().Add(s.opts.probeTimeout)
 	}
 
 	// Set the deadline to be the lowest of the two times.

--- a/service/envvars.go
+++ b/service/envvars.go
@@ -69,4 +69,7 @@ const (
 
 	// EnvKubeNodeName is the name of the environment variable which stores current kubernetes node name
 	EnvKubeNodeName = "X_CSI_POWERFLEX_KUBE_NODE_NAME"
+
+	// EnvMaxProbeTimeout is the name of the environment variable which stores the maximum probe timeout
+	EnvMaxProbeTimeout = "X_CSI_PROBE_TIMEOUT"
 )

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1265,6 +1265,15 @@ Feature: VxFlex OS CSI interface
     # Get different error message on Windows vs. Linux
     Then the error contains "unable to login to PowerFlex Gateway"
 
+  Scenario: Test BeforeServe with Env variable modification
+    Given a VxFlexOS service
+    When I call GetPluginInfo
+    When I call BeforeServe but change <envVar> with <value>
+    Examples:
+      | envVar                   | value     |
+      | "X_CSI_PROBE_TIMEOUT"    | "myValue" |
+      | "X_CSI_PROBE_TIMEOUT"    | "5s"      |
+
   Scenario: Test getArrayConfig with invalid config file
     Given an invalid config <configPath>
     When I call getArrayConfig

--- a/service/service.go
+++ b/service/service.go
@@ -189,6 +189,7 @@ type Opts struct {
 	ExternalAccess             string // used for adding extra IP/IP range to the NFS export
 	KubeNodeName               string
 	zoneLabelKey               string
+	probeTimeout               time.Duration
 }
 
 type service struct {
@@ -518,6 +519,20 @@ func (s *service) BeforeServe(
 		Log.WithError(err).Error("unable to log csiNode topology keys")
 	}
 
+	opts.probeTimeout = DefaultAPITimeout
+	if envProbeTimeout, ok := csictx.LookupEnv(ctx, EnvMaxProbeTimeout); ok {
+		duration, err := time.ParseDuration(envProbeTimeout)
+		if err != nil {
+			Log.Warnf("error while parsing env variable '%s', %s, defaulting to %s", EnvMaxProbeTimeout, err, DefaultAPITimeout)
+			opts.probeTimeout = DefaultAPITimeout
+		} else {
+			Log.Infof("env variable '%s' provided with value %s", EnvMaxProbeTimeout, envProbeTimeout)
+			opts.probeTimeout = duration
+		}
+	} else {
+		Log.Infof("env variable '%s' not provided, defaulting to %s", EnvMaxProbeTimeout, DefaultAPITimeout)
+	}
+
 	// pb parses an environment variable into a boolean value. If an error
 	// is encountered, default is set to false, and error is logged
 	pb := func(n string) bool {
@@ -544,14 +559,13 @@ func (s *service) BeforeServe(
 	s.updateConfigMap(s.getIPAddressByInterface, ConfigMapFilePath)
 
 	if _, ok := csictx.LookupEnv(ctx, "X_CSI_VXFLEXOS_NO_PROBE_ON_START"); !ok {
-		Log.Printf("BeforeServe probing starting %s", time.Now().Format("15:04:05.000000000"))
-		// probe before the server starts, to avoid errors in the controller, we must return before 2 seconds.
-		beforeServeMaxTimeout := 1 * time.Second
-		newContext, cancel := context.WithDeadline(ctx, time.Now().Add(beforeServeMaxTimeout))
+		Log.Infof("BeforeServe probing starting %s", time.Now().Format("15:04:05.000000000"))
+		newContext, cancel := context.WithDeadline(ctx, time.Now().Add(s.opts.probeTimeout))
 		defer cancel()
 
 		err := s.doProbe(newContext)
-		Log.Printf("BeforeServe probing complete %s", time.Now().Format("15:04:05.000000000"))
+
+		Log.Infof("BeforeServe probing complete %s", time.Now().Format("15:04:05.000000000"))
 		return err
 	}
 


### PR DESCRIPTION
# Description
An escalation came in that identified that the 1 second default timeout to communicate to the array was too restrictive and was causing **CrashLoopBackOff** if an array took just too long to respond. Also, after communication with the PowerFlex team, an array should respond within 10 second so we have decided to make that the default timeout.

This is needed in the `BeforeServe` code specifically because
1. We don't have a Deadline which is passed through a context so we need to configure it ourselves
2. With the configurable timeout, it needs to be properly set for future probes as the default timeout.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensured that when the environment variable is not set, we select the 10 second timeout.
- [x] Ensured that when the environment variable is set, we properly parse the contents.
- [x] Added new unit tests to cover the above scenarios.
- [x] Tested in cluster to ensure the functionality is not effected and controller/node both continue to a running state.
