### PR TITLE
Configurable Probe Timeout (#497)

### DIFF
--- a/service/controller.go
+++ b/service/controller.go
@@ -137,7 +137,7 @@ const (
 
 	DriverConfigParamsYaml = "driver-config-params.yaml"
 
-	DefaultAPITimeout = 5 * time.Second
+	DefaultAPITimeout = 10 * time.Second
 
 	// MaxVolumeListEntries limits the page size for ListVolumes, since even a few hundred volumes
 	// in the ListVolumeResponse will cause gRPC connection failure between the driver and CO.
@@ -2668,7 +2668,7 @@ func (s *service) systemProbeAll(ctx context.Context) error {
 		Log.Infof("probing zoneLabel '%s', zone value: '%s'", s.opts.zoneLabelKey, zoneName)
 	}
 
-	newCtx, cancel := createProbeContextWithDeadline(ctx)
+	newCtx, cancel := s.createProbeContextWithDeadline(ctx)
 	defer cancel()
 
 	for _, array := range s.opts.arrays {
@@ -3798,12 +3798,12 @@ func (s *service) verifySystem(systemID string) (*goscaleio.Client, error) {
 	return adminClient, nil
 }
 
-func createProbeContextWithDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
-	defaultProbeDeadline := time.Now().Add(DefaultAPITimeout)
+func (s *service) createProbeContextWithDeadline(ctx context.Context) (context.Context, context.CancelFunc) {
+	defaultProbeDeadline := time.Now().Add(s.opts.probeTimeout)
 	probeDeadline, ok := ctx.Deadline()
 	if !ok {
 		Log.Println("Probe deadline not in context, using default")
-		probeDeadline = time.Now().Add(DefaultAPITimeout)
+		probeDeadline = time.Now().Add(s.opts.probeTimeout)
 	}
 
 	// Set the deadline to be the lowest of the two times.

--- a/service/envvars.go
+++ b/service/envvars.go
@@ -69,4 +69,7 @@ const (
 
 	// EnvKubeNodeName is the name of the environment variable which stores current kubernetes node name
 	EnvKubeNodeName = "X_CSI_POWERFLEX_KUBE_NODE_NAME"
+
+	// EnvMaxProbeTimeout is the name of the environment variable which stores the maximum probe timeout
+	EnvMaxProbeTimeout = "X_CSI_PROBE_TIMEOUT"
 )

--- a/service/features/service.feature
+++ b/service/features/service.feature
@@ -1266,6 +1266,15 @@ Feature: VxFlex OS CSI interface
     # Get different error message on Windows vs. Linux
     Then the error contains "unable to login to PowerFlex Gateway"
 
+  Scenario: Test BeforeServe with Env variable modification
+    Given a VxFlexOS service
+    When I call GetPluginInfo
+    When I call BeforeServe but change <envVar> with <value>
+    Examples:
+      | envVar                   | value     |
+      | "X_CSI_PROBE_TIMEOUT"    | "myValue" |
+      | "X_CSI_PROBE_TIMEOUT"    | "5s"      |
+
   Scenario: Test getArrayConfig with invalid config file
     Given an invalid config <configPath>
     When I call getArrayConfig

--- a/service/step_defs_test.go
+++ b/service/step_defs_test.go
@@ -360,6 +360,8 @@ MDM-ID 14dbbf5617523654 SDC ID d0f33bd700000004 INSTALLATION ID 1c078b073d75512c
 
 	opts.replicationPrefix = "replication.storage.dell.com"
 
+	opts.probeTimeout = 10 * time.Second
+
 	svc.opts = opts
 
 	if f.system != nil {
@@ -3325,7 +3327,7 @@ func (f *feature) theConfigMapIsUpdated() error {
 	return nil
 }
 
-func (f *feature) iCallBeforeServe() error {
+func setUpBeforeServeContext() (interface{}, []string) {
 	ctxOSEnviron := interface{}("os.Environ")
 	stringSlice := make([]string, 0)
 	stringSlice = append(stringSlice, "X_CSI_PRIVATE_MOUNT_DIR=/csi")
@@ -3344,17 +3346,39 @@ func (f *feature) iCallBeforeServe() error {
 		fmt.Printf("debug set ALLOW_RWO_MULTI_POD\n")
 		stringSlice = append(stringSlice, "X_CSI_ALLOW_RWO_MULTI_POD_ACCESS=true")
 	}
+
+	return ctxOSEnviron, stringSlice
+}
+
+func (f *feature) iCallBeforeServe() error {
+	ctxOSEnviron, stringSlice := setUpBeforeServeContext()
 	ctx := context.WithValue(context.Background(), ctxOSEnviron, stringSlice)
+	return f.executeBeforeServe(ctx)
+}
+
+func (f *feature) iCallBeforeServeButChangeWithValue(arg1 string, arg2 string) error {
+	ctxOSEnviron, stringSlice := setUpBeforeServeContext()
+	ctx := context.WithValue(context.Background(), ctxOSEnviron, stringSlice)
+
+	// Setting the appropriate value.
+	os.Setenv(arg1, arg2)
+
+	return f.executeBeforeServe(ctx)
+}
+
+func (f *feature) executeBeforeServe(ctx context.Context) error {
 	listener, err := net.Listen("tcp", "127.0.0.1:65000")
 	if err != nil {
 		return err
 	}
+
 	os.Setenv(EnvAutoProbe, "true")
 	presp, perr := f.service.ProbeController(ctx, nil)
 	fmt.Printf("ProbeController resp %#v \n", presp)
 	if perr != nil {
 		f.err = perr
 	}
+
 	if stepHandlersErrors.UpdateConfigK8sClientError {
 		K8sClientset = nil
 	}
@@ -5179,6 +5203,7 @@ func FeatureContext(s *godog.ScenarioContext) {
 	s.Step(`^a NodeGetInfo is returned without zone topology$`, f.aNodeGetInfoIsReturnedWithoutZoneTopology)
 	s.Step(`^a NodeGetInfo is returned without zone system topology$`, f.aNodeGetInfoIsReturnedWithoutZoneSystemTopology)
 	s.Step(`^I call systemProbeAll in mode "([^"]*)"`, f.iCallSystemProbeAll)
+	s.Step(`^I call BeforeServe but change "([^"]*)" with "([^"]*)"$`, f.iCallBeforeServeButChangeWithValue)
 
 	s.Before(func(ctx context.Context, _ *godog.Scenario) (context.Context, error) {
 		// Cleanup test directory before each test


### PR DESCRIPTION
# Description
Cherry Picked: https://github.com/dell/csi-powerflex/pull/497

An escalation came in that identified that the 1 second default timeout to communicate to the array was too restrictive and was causing 1CrashLoopBackOff1 if an array took just too long to respond. Also, after communication with the PowerFlex team, an array should respond within 10 second so we have decided to make that the default timeout.

This is needed in the BeforeServe code specifically because

- We don't have a Deadline which is passed through a context so we need to configure it ourselves
- With the configurable timeout, it needs to be properly set for future probes as the default timeout.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1956 |

# Checklist:

- [x] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [x] I have verified that new and existing unit tests pass locally with my changes
- [x] I have not allowed coverage numbers to degenerate
- [x] I have maintained at least 90% code coverage
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Backward compatibility is not broken

# How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Please also list any relevant details for your test configuration

- [x] Ensured that when the environment variable is not set, we select the 10 second timeout.
- [x] Ensured that when the environment variable is set, we properly parse the contents.
- [x] Added new unit tests to cover the above scenarios.
- [x]  Tested in cluster to ensure the functionality is not effected and controller/node both continue to a running state.
