### PR TITLE
Update Release Workflow 

### DIFF
--- a/.github/workflows/create-tag-release.yaml
+++ b/.github/workflows/create-tag-release.yaml
@@ -1,4 +1,4 @@
-name: Release CSI-Powerflex
+name: Create Tag and Release
 # Invocable as a reusable workflow
 # Can be manually triggered
 on:  # yamllint disable-line rule:truthy
@@ -21,6 +21,7 @@ on:  # yamllint disable-line rule:truthy
         type: string
   repository_dispatch:
     types: [auto-release-workflow]
+
 jobs:
   process-inputs:
     name: Process Inputs
@@ -38,22 +39,31 @@ jobs:
             exit 0
           fi
           if [[ "${{ github.event.inputs.version }}" != "" && "${{ github.event.inputs.option }}" == "n-1/n-2 patch (Provide input in the below box)" ]]; then
-            # if both version and option are provided, then version takes precedence i.e. patch release for n-1/n-2
             echo "versionEnv=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
             exit 0
           fi
           if [[ "${{ github.event.inputs.option }}" != "n-1/n-2 patch (Provide input in the below box)" ]]; then
-            # if only option is provided, then option takes precedence i.e. minor, major or patch release
             echo "versionEnv=${{ github.event.inputs.option }}" >> $GITHUB_OUTPUT
             exit 0
           fi
-          # if neither option nor version is provided, then minor release is taken by default (Auto-release)
           echo "versionEnv=minor" >> $GITHUB_OUTPUT
+
   csm-release:
-    needs: [process-inputs]
-    uses: dell/common-github-actions/.github/workflows/csm-release-driver-module.yaml@main
-    name: Release CSM Drivers and Modules
+    needs: process-inputs
+    uses: dell/common-github-actions/.github/workflows/create-tag-release.yaml@main
+    name: Create Tag and Release
     with:
       version: ${{ needs.process-inputs.outputs.processedVersion }}
       images: 'csi-vxflexos'
     secrets: inherit
+
+  next-steps:
+    name: 📌 Next Steps for Release Process
+    runs-on: ubuntu-latest
+    needs: csm-release
+    steps:
+      - name: Share next steps with user
+        run: |
+          echo "✅ Tag and release completed."
+          echo "➡️ Please manually trigger the Jenkins image build job: CSM-Images-Build-Nightly."
+          echo "🚀 Once the Jenkins image build job is successful, trigger the Release Image workflow from GitHub Actions."

--- a/.github/workflows/release-image.yaml
+++ b/.github/workflows/release-image.yaml
@@ -1,0 +1,59 @@
+name: Release CSI-Powerflex Image
+# Invocable as a reusable workflow
+# Can be manually triggered
+on:  # yamllint disable-line rule:truthy
+  workflow_call:
+  workflow_dispatch:
+    inputs:
+      option:
+        description: 'Select version to release'
+        required: true
+        type: choice
+        default: 'minor'
+        options:
+          - major
+          - minor
+          - patch
+          - n-1/n-2 patch (Provide input in the below box)
+      version:
+        description: "Patch version to release. example: 2.1.x (Use this only if n-1/n-2 patch is selected)"
+        required: false
+        type: string
+  repository_dispatch:
+    types: [auto-release-workflow]
+jobs:
+  process-inputs:
+    name: Process Inputs
+    runs-on: ubuntu-latest
+    outputs:
+      processedVersion: ${{ steps.set-version.outputs.versionEnv }}
+    steps:
+      - name: Process input
+        id: set-version
+        shell: bash
+        run: |
+          echo "Triggered by: ${{ github.event_name }}"
+          if [[ "${{ github.event_name }}" == "repository_dispatch" ]]; then
+            echo "versionEnv=minor" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "${{ github.event.inputs.version }}" != "" && "${{ github.event.inputs.option }}" == "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if both version and option are provided, then version takes precedence i.e. patch release for n-1/n-2
+            echo "versionEnv=${{ github.event.inputs.version }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          if [[ "${{ github.event.inputs.option }}" != "n-1/n-2 patch (Provide input in the below box)" ]]; then
+            # if only option is provided, then option takes precedence i.e. minor, major or patch release
+            echo "versionEnv=${{ github.event.inputs.option }}" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          # if neither option nor version is provided, then minor release is taken by default (Auto-release)
+          echo "versionEnv=minor" >> $GITHUB_OUTPUT
+  csm-release:
+    needs: [process-inputs]
+    uses: dell/common-github-actions/.github/workflows/release-image.yaml@main
+    name: Release Image
+    with:
+      version: ${{ needs.process-inputs.outputs.processedVersion }}
+      images: 'csi-vxflexos'
+    secrets: inherit


### PR DESCRIPTION
# Description
 I've split the release workflow into two distinct parts:

- Create Tag and Release
- Release Image

This change was made to address an issue in the previous workflow where images were being released with incorrect semantic versioning. By separating the workflows, we now:

- First, create the release tag.
- Then, manually rebuild the nightly image to ensure it includes the correct semver version.
- Finally, trigger the Release Image workflow, which now reliably publishes images with the correct version.

# GitHub Issues
List the GitHub issues impacted by this PR:

| GitHub Issue # |
| -------------- |
| https://github.com/dell/csm/issues/1995

# Checklist:

- [X] I have performed a self-review of my own code to ensure there are no formatting, vetting, linting, or security issues
- [X] I have not allowed coverage numbers to degenerate
- [X] I have maintained at least 90% code coverage
- [X] I have commented my code, particularly in hard-to-understand areas


# How Has This Been Tested?
This is tested in forked repo, created the tag and release, pushed the images to test quay folder

<img width="644" height="111" alt="create tag" src="https://github.com/user-attachments/assets/341a9a16-ce6d-4385-99fd-fb976bc232c7" />

<img width="426" height="134" alt="release " src="https://github.com/user-attachments/assets/859fb250-e5d1-4525-862a-352c238b9f1d" />

